### PR TITLE
Update for DuckDB 0.8.1 and enable DB name in table name

### DIFF
--- a/deparse.c
+++ b/deparse.c
@@ -193,8 +193,12 @@ sqlite_deparse_relation(StringInfo buf, Relation rel)
 	if (relname == NULL)
 		relname = RelationGetRelationName(rel);
 
-	/* always use main database for SQLite */
-	appendStringInfo(buf, "%s.%s", "main", sqlite_quote_identifier(relname, QUOTE));
+	/* 
+	 * DuckDB now has the concept of multiple databases, so pass the table name in 
+	 * without prepending "main" and without quotes. 
+	 * Ex: my_db.my_schema.my_table is allowed
+	 */
+	appendStringInfo(buf, "%s", relname);
 }
 
 static char *


### PR DESCRIPTION
Hello! Please let me know if there is anything else you'd like for me to do to make this easy to merge!

I made some minimal changes to the sqlite wrapper to support DuckDB 0.8.1 (just putting certain things within the DuckDB namespace). 

I also changed how table names are handled. After the `Attach` syntax was added, DuckDB now has the concepts of database and schema. As a result, if a user passes in a fully qualified table name like `my_db.my_schema.my_table`, adding "main" or wrapping in double quotes would cause errors. This is also needed for MotherDuck to be able to be supported as a connection, as MotherDuck uses multiple databases. 