### PR TITLE
Support for list type, array_agg, filter on the remote server

### DIFF
--- a/deparse.c
+++ b/deparse.c
@@ -843,7 +843,9 @@ sqlite_foreign_expr_walker(Node *node,
 					  || strcmp(opername, "array_agg") == 0
 					  || strcmp(opername, "stddev_pop") == 0
 					  || strcmp(opername, "stddev_samp") == 0
+					  || strcmp(opername, "mode") == 0
 					  || strcmp(opername, "percentile_cont") == 0
+					  || strcmp(opername, "percentile_disc") == 0
 					  || strcmp(opername, "count") == 0))
 				{
 					return false;

--- a/deparse.c
+++ b/deparse.c
@@ -151,6 +151,7 @@ static Node *sqlite_deparse_sort_group_clause(Index ref, List *tlist, bool force
 											  deparse_expr_cxt *context);
 static void sqlite_deparse_explicit_target_list(List *tlist, List **retrieved_attrs,
 												deparse_expr_cxt *context);
+static void sqlite_deparse_minmax_expr(MinMaxExpr *node, deparse_expr_cxt *context);
 
 /*
  * Helper functions
@@ -924,6 +925,43 @@ sqlite_foreign_expr_walker(Node *node,
 				 * an input foreign Var (same logic as for a function).
 				 */
 				collation = a->array_collid;
+				if (collation == InvalidOid)
+					state = FDW_COLLATE_NONE;
+				else if (inner_cxt.state == FDW_COLLATE_SAFE &&
+						 collation == inner_cxt.collation)
+					state = FDW_COLLATE_SAFE;
+				else if (collation == DEFAULT_COLLATION_OID)
+					state = FDW_COLLATE_NONE;
+				else
+					state = FDW_COLLATE_UNSAFE;
+			}
+			break;
+		case T_MinMaxExpr:
+			{
+				MinMaxExpr *mmexpr = (MinMaxExpr *) node;
+
+				if (mmexpr->op != IS_LEAST && mmexpr->op != IS_GREATEST)
+					return false;
+
+				if (!sqlite_foreign_expr_walker((Node *) mmexpr->args,
+												glob_cxt, &inner_cxt))
+					return false;
+
+				/*
+				 * If minmax's input collation is not derived from a foreign
+				 * Var, it can't be sent to remote.
+				 */
+				if (mmexpr->inputcollid == InvalidOid)
+					 /* OK, inputs are all noncollatable */ ;
+				else if (inner_cxt.state != FDW_COLLATE_SAFE ||
+						 mmexpr->inputcollid != inner_cxt.collation)
+					return false;
+
+				/*
+				 * MinMaxExpr must not introduce a collation not derived from
+				 * an input foreign Var (same logic as for a function).
+				 */
+				collation = mmexpr->minmaxcollid;
 				if (collation == InvalidOid)
 					state = FDW_COLLATE_NONE;
 				else if (inner_cxt.state == FDW_COLLATE_SAFE &&
@@ -2066,6 +2104,9 @@ sqlite_deparse_expr(Expr *node, deparse_expr_cxt *context)
 		case T_NullIfExpr:
 			sqlite_deparse_null_if_expr((NullIfExpr *) node, context);
 			break;
+		case T_MinMaxExpr:
+			sqlite_deparse_minmax_expr((MinMaxExpr *) node, context);
+			break;
 		case T_Aggref:
 			sqlite_deparse_aggref((Aggref *) node, context);
 			break;
@@ -3065,6 +3106,37 @@ sqlite_deparse_coalesce_expr(CoalesceExpr *node, deparse_expr_cxt *context)
 	bool		first = true;
 
 	appendStringInfoString(buf, "COALESCE(");
+	foreach(lc, node->args)
+	{
+		if (!first)
+			appendStringInfoString(buf, ", ");
+		first = false;
+
+		sqlite_deparse_expr(lfirst(lc), context);
+	}
+	appendStringInfoChar(buf, ')');
+}
+
+/*
+ * Deparse given MinMaxExpr node.
+ */
+static void
+sqlite_deparse_minmax_expr(MinMaxExpr *node, deparse_expr_cxt *context)
+{
+	StringInfo	buf = context->buf;
+	ListCell   *lc;
+	bool		first = true;
+
+	/* Check operation accepted. */
+	Assert(node->op == IS_LEAST || node->op == IS_GREATEST);
+
+	if (node->op == IS_LEAST) {
+		appendStringInfoString(buf, "LEAST(");
+	}
+	else {
+		appendStringInfoString(buf, "GREATEST(");
+	}
+
 	foreach(lc, node->args)
 	{
 		if (!first)

--- a/deparse.c
+++ b/deparse.c
@@ -539,6 +539,8 @@ sqlite_foreign_expr_walker(Node *node,
 				 */
 				if (!(func->funcformat == COERCE_IMPLICIT_CAST
 					  || strcmp(opername, "abs") == 0
+					  || strcmp(opername, "floor") == 0
+					  || strcmp(opername, "ceil") == 0
 					  || strcmp(opername, "btrim") == 0
 					  || strcmp(opername, "length") == 0
 					  || strcmp(opername, "ltrim") == 0

--- a/deparse.c
+++ b/deparse.c
@@ -193,9 +193,9 @@ sqlite_deparse_relation(StringInfo buf, Relation rel)
 	if (relname == NULL)
 		relname = RelationGetRelationName(rel);
 
-	/* 
-	 * DuckDB now has the concept of multiple databases, so pass the table name in 
-	 * without prepending "main" and without quotes. 
+	/*
+	 * DuckDB now has the concept of multiple databases, so pass the table name in
+	 * without prepending "main" and without quotes.
 	 * Ex: my_db.my_schema.my_table is allowed
 	 */
 	appendStringInfo(buf, "%s", relname);
@@ -837,6 +837,7 @@ sqlite_foreign_expr_walker(Node *node,
 					  || strcmp(opername, "avg") == 0
 					  || strcmp(opername, "max") == 0
 					  || strcmp(opername, "min") == 0
+					  || strcmp(opername, "array_agg") == 0
 					  || strcmp(opername, "count") == 0))
 				{
 					return false;
@@ -3122,7 +3123,7 @@ sqlite_is_builtin(Oid oid)
 {
 #if PG_VERSION_NUM >= 120000
 	return (oid < FirstGenbkiObjectId);
-#else 
+#else
 	return (oid < FirstBootstrapObjectId);
 #endif
 }

--- a/deparse.c
+++ b/deparse.c
@@ -873,7 +873,7 @@ sqlite_foreign_expr_walker(Node *node,
 						return false;
 				}
 
-				if (agg->aggorder || agg->aggfilter)
+				if (agg->aggorder /* || agg->aggfilter --> FILTER expression can be evaluated on the remote server */)
 				{
 					return false;
 				}

--- a/deparse.c
+++ b/deparse.c
@@ -841,6 +841,9 @@ sqlite_foreign_expr_walker(Node *node,
 					  || strcmp(opername, "max") == 0
 					  || strcmp(opername, "min") == 0
 					  || strcmp(opername, "array_agg") == 0
+					  || strcmp(opername, "stddev_pop") == 0
+					  || strcmp(opername, "stddev_samp") == 0
+					  || strcmp(opername, "percentile_cont") == 0
 					  || strcmp(opername, "count") == 0))
 				{
 					return false;
@@ -874,11 +877,6 @@ sqlite_foreign_expr_walker(Node *node,
 
 					if (!sqlite_foreign_expr_walker(n, glob_cxt, &inner_cxt))
 						return false;
-				}
-
-				if (agg->aggorder /* || agg->aggfilter --> FILTER expression can be evaluated on the remote server */)
-				{
-					return false;
 				}
 
 				/*

--- a/sqlite3.h
+++ b/sqlite3.h
@@ -33,6 +33,7 @@
 #ifndef SQLITE3_H
 #define SQLITE3_H
 #include <stdarg.h>     /* Needed for the definition of va_list */
+#include <stdint.h>     /* Needed for the definition of uintptr_t */
 
 /*
 ** Make sure we can call this stuff from C++.
@@ -65,6 +66,16 @@ extern "C" {
 #endif
 #ifndef SQLITE_SYSAPI
 # define SQLITE_SYSAPI
+#endif
+
+/*
+** Ensure symbols of fundamental types in Postgres.
+ */
+#ifndef Oid
+typedef unsigned int Oid;
+#endif
+#ifndef Datum
+typedef uintptr_t Datum;
 #endif
 
 /*
@@ -4962,6 +4973,9 @@ SQLITE_API int sqlite3_data_count(sqlite3_stmt *pStmt);
 ** by invoking the [sqlite3_errcode()] immediately after the suspect
 ** return value is obtained and before any
 ** other SQLite interface is called on the same [database connection].
+**
+** ^The sqlite3_column_value_datum() routine returns the value as Postgres
+** Datum type for the data type of the result column.
 */
 SQLITE_API const void *sqlite3_column_blob(sqlite3_stmt*, int iCol);
 SQLITE_API double sqlite3_column_double(sqlite3_stmt*, int iCol);
@@ -4973,6 +4987,7 @@ SQLITE_API sqlite3_value *sqlite3_column_value(sqlite3_stmt*, int iCol);
 SQLITE_API int sqlite3_column_bytes(sqlite3_stmt*, int iCol);
 SQLITE_API int sqlite3_column_bytes16(sqlite3_stmt*, int iCol);
 SQLITE_API int sqlite3_column_type(sqlite3_stmt*, int iCol);
+SQLITE_API bool sqlite3_column_value_datum(sqlite3_stmt*, int iCol, Oid pgType, Datum *value);
 
 /*
 ** CAPI3REF: Destroy A Prepared Statement Object

--- a/sqlite3_api_wrapper.cpp
+++ b/sqlite3_api_wrapper.cpp
@@ -771,7 +771,7 @@ static bool duckdb_value_as_datum(const Value &val, Oid pgType, Datum *value) {
 		}
 
 		Datum array_result = makeArrayResult(astate, CurrentMemoryContext);
-		*value = PointerGetDatum(array_result);
+		*value = array_result;
 		return true;
 	}
 	case LogicalTypeId::VARCHAR:
@@ -779,7 +779,7 @@ static bool duckdb_value_as_datum(const Value &val, Oid pgType, Datum *value) {
 	{
 		std::string value_s = val.ToString();
 
-		text *text_ptr = (text *) palloc(value_s.size() + VARHDRSZ);
+		char *text_ptr = (char *) palloc(value_s.size() + VARHDRSZ);
 		SET_VARSIZE(text_ptr, value_s.size() + VARHDRSZ);
 		memcpy(VARDATA(text_ptr), value_s.c_str(), value_s.size());
 

--- a/sqlite_query.c
+++ b/sqlite_query.c
@@ -128,7 +128,7 @@ sqlite_convert_to_pg(Oid pgtyp, int pgtypmod, sqlite3_stmt * stmt, int attnum, A
 				value_datum = (Datum) palloc0(blobsize + VARHDRSZ);
 				memcpy(VARDATA(value_datum), sqlite3_column_blob(stmt, attnum), blobsize);
 				SET_VARSIZE(value_datum, blobsize + VARHDRSZ);
-				return PointerGetDatum(value_datum);
+				return PointerGetDatum((const void *)value_datum);
 			}
 		case INT2OID:
 			{

--- a/sqlite_query.c
+++ b/sqlite_query.c
@@ -93,6 +93,15 @@ sqlite_convert_to_pg(Oid pgtyp, int pgtypmod, sqlite3_stmt * stmt, int attnum, A
 	if (sqlite_type != col_type && col_type == SQLITE3_TEXT)
 		elog(ERROR, "invalid input syntax for type =%d, column type =%d", sqlite_type, col_type);
 
+	/* if value is a list, build and return an array of values */
+	if (type_is_array(pgtyp)) {
+		bool result = sqlite3_column_value_datum(stmt, attnum, pgtyp, &value_datum);
+		if (!result)
+			elog(ERROR, "sqlite3_column_value_datum failed for type =%d, column type =%d", pgtyp, col_type);
+
+		return value_datum;
+	}
+
 	switch (pgtyp)
 	{
 			/*


### PR DESCRIPTION
This PR provides two features:
* Adds support for List type, to manage functions that returns arrays of values.
* Enable to run `array_agg` function on the remote server with DuckDB.
* Enable to run `FILTER` expression as well
* Enable to run `ceil`/`floor` functions on the remote server
* Enable to run `least`/`greatest` expressions on the remote server
* Enable to run `stddev_pop`, `stddev_samp` and `percentile_cont` functions on the remote server
* Enable to run `WITHIN GROUP (ORDER BY ..)` expression on the remote server
* Enable to run `mode` & `percentile_disc` functions on the remote server