### PR TITLE
Multiarch support for both x86_64 and arm64 (Mac M1)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,10 @@ endif
 ifeq ($(detected_OS),Linux)
     # DLSUFFIX = .so
     PG_CXXFLAGS = -std=c++11
+    detected_arch := $(shell uname -m)
+    ifeq ($(detected_arch),x86_64)
+        PG_CXXFLAGS = -std=c++11 -D_GLIBCXX_USE_CXX11_ABI=0
+    endif
 endif
 
 SHLIB_LINK := -lduckdb -lstdc++

--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,9 @@ ifeq ($(detected_OS),Linux)
     endif
 endif
 
+$(uname -a)
+$(echo FLAGS $PG_CXXFLAGS) 
+
 SHLIB_LINK := -lduckdb -lstdc++
 
 ifdef USE_PGXS

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ ifeq ($(detected_OS),Darwin)        # Mac OS X
 endif
 ifeq ($(detected_OS),Linux)
     # DLSUFFIX = .so
-    PG_CXXFLAGS = -std=c++11 -D_GLIBCXX_USE_CXX11_ABI=0
+    PG_CXXFLAGS = -std=c++11
 endif
 
 SHLIB_LINK := -lduckdb -lstdc++

--- a/Makefile
+++ b/Makefile
@@ -44,9 +44,6 @@ ifeq ($(detected_OS),Linux)
     endif
 endif
 
-$(uname -a)
-$(echo FLAGS $PG_CXXFLAGS) 
-
 SHLIB_LINK := -lduckdb -lstdc++
 
 ifdef USE_PGXS


### PR DESCRIPTION
the  _GLIBCXX_USE_CXX11_ABI=0 flag is only needed on x86_64 and causes linker errors on arm64 platform such as Mac M1

Corresponding changes to dockerfile here in a second