### PR TITLE
add docker support to main code repo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,52 @@
+# Use an official PostgreSQL image as the base image
+ARG POSTGRES_VERSION=16
+FROM postgres:${POSTGRES_VERSION} AS builder
+
+# Set default values for build arguments
+ARG POSTGRES_VERSION=16
+ARG DUCKDB_VERSION=0.9.2
+
+# Install build dependencies
+RUN apt-get update && apt-get install -y \
+  git \
+  build-essential \
+  cmake \
+  postgresql-server-dev-${POSTGRES_VERSION} \
+  postgresql-client-${POSTGRES_VERSION} \
+  wget \
+  unzip
+
+# add local checkout
+ADD . duckdb_fdw
+
+# build fdw
+RUN cd duckdb_fdw \
+   && export DUCK_ARCH=$(uname -m | sed -e s/arm64/aarch64/ | sed -e s/x86_64/amd64/) \
+   && wget -c https://github.com/duckdb/duckdb/releases/download/v${DUCKDB_VERSION}/libduckdb-linux-${DUCK_ARCH}.zip \
+   && unzip -o -d . libduckdb-linux-${DUCK_ARCH}.zip \
+   && cp libduckdb.so $(pg_config --libdir) \
+   && make USE_PGXS=1 \
+   && make install USE_PGXS=1
+
+# Set environment variables
+ENV POSTGRES_HOST_AUTH_METHOD='trust'
+
+
+# Switch to the postgres user
+USER postgres
+
+# Optionally, you might want to include additional configurations or initialization steps here
+
+# Create the final image
+FROM postgres:${POSTGRES_VERSION}
+ARG POSTGRES_VERSION=16
+
+# Copy duckdb_fdw artifacts from the builder stage
+COPY --from=builder duckdb_fdw/duckdb_fdw.so /usr/lib/postgresql/${POSTGRES_VERSION}/lib/
+COPY --from=builder duckdb_fdw/duckdb_fdw.control /usr/share/postgresql/${POSTGRES_VERSION}/extension/
+COPY --from=builder duckdb_fdw/duckdb_fdw*.sql /usr/share/postgresql/${POSTGRES_VERSION}/extension/
+
+# Horrible workaround for Docker's completely brain damaged multiplatform builds
+RUN mkdir /usr/lib/platform
+COPY --from=builder /usr/lib/*-linux-gnu/libduckdb.so /usr/lib/platform/
+RUN ln -sf /usr/lib/platform/libduckdb.so /usr/lib/$(uname -m | sed -e s/arm64/aarch64/)-linux-gnu/libduckdb.so

--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,10 @@ endif
 ifeq ($(detected_OS),Linux)
     # DLSUFFIX = .so
     PG_CXXFLAGS = -std=c++11
+    detected_arch := $(shell uname -m)
+    ifeq ($(detected_arch),x86_64)
+        PG_CXXFLAGS = -std=c++11 -D_GLIBCXX_USE_CXX11_ABI=0
+    endif
 endif
 
 SHLIB_LINK := -lduckdb -lstdc++

--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,9 @@ ifeq ($(detected_OS),Linux)
     endif
 endif
 
+$(uname -a)
+$(echo FLAGS $PG_CXXFLAGS) 
+
 SHLIB_LINK := -lduckdb -lstdc++
 
 ifdef USE_PGXS

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ ifeq ($(detected_OS),Darwin)        # Mac OS X
 endif
 ifeq ($(detected_OS),Linux)
     # DLSUFFIX = .so
-    PG_CXXFLAGS = -std=c++11 -D_GLIBCXX_USE_CXX11_ABI=0
+    PG_CXXFLAGS = -std=c++11
 endif
 
 SHLIB_LINK := -lduckdb -lstdc++

--- a/Makefile
+++ b/Makefile
@@ -44,9 +44,6 @@ ifeq ($(detected_OS),Linux)
     endif
 endif
 
-$(uname -a)
-$(echo FLAGS $PG_CXXFLAGS) 
-
 SHLIB_LINK := -lduckdb -lstdc++
 
 ifdef USE_PGXS

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,38 @@
+version: "3.3"
+services:
+    duckdb_fdw0:
+        build:
+            context: .
+            args:
+                - POSTGRES_VERSION=16
+                - DUCKDB_VERSION=0.9.2
+        ports:
+            - "5432:5432"
+        volumes:
+            - pg_data:/var/lib/postgresql/data
+            - duckdb_data:/var/lib/postgresql/duckdb
+        environment:
+            - POSTGRES_USER=postgres
+            - POSTGRES_DB=postgres
+            - POSTGRES_PASSWORD=qwert
+        # depends_on:
+        #     - mdata
+
+volumes:
+    initdb-scripts:
+        driver: local
+
+    pg_data: # Additional volume to mount the SQL script
+        driver: local
+        driver_opts:
+            o: bind
+            type: none
+            device: /Users/pete/tmp/pgduck/pg
+
+    duckdb_data:
+        driver: local
+        driver_opts: 
+            o: bind
+            type: none
+            device: /Users/pete/tmp/pgduck/duckdb
+

--- a/test_script.sql
+++ b/test_script.sql
@@ -1,0 +1,7 @@
+-- test_script.sql
+DROP EXTENSION IF EXISTS duckdb_fdw CASCADE;
+CREATE EXTENSION duckdb_fdw;
+CREATE SERVER DuckDB_server FOREIGN DATA WRAPPER duckdb_fdw OPTIONS (database ':memory:');  
+SELECT duckdb_execute('duckdb_server','CREATE VIEW tables_duckdb AS SELECT *  FROM information_schema.tables');
+IMPORT FOREIGN SCHEMA public  FROM SERVER DuckDB_server INTO public; 
+SELECT * FROM tables_duckdb;


### PR DESCRIPTION
This PR stacks on the multiarch PRs (and is just the dockerfiles/makefile changes from those) In addition to convenience, it fixes several problems:

- development workflow across multiple repositories was a huge pain in the neck
- `ADD`ing the code is best practice and makes local development easier
- **most important**, the old `git clone https://some_repo_without_a_tag` **breaks docker's layer caching**: as previously implemented, docker had no way of knowing when the code in the repo had changed and building a new image required manually flushing the cache (via `docker build prune -a`). This was source of subtle errors if you forgot to flush or otherwise slow.
