### PR TITLE
Add temp_directory option to connection settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,10 @@ make install
 
   Specifies the number of rows which should be inserted in a single `INSERT` operation. This setting can be overridden for individual tables.
   
+- **temp_directory** as *string*,  optional, default *NULL*
+  
+  Specifies the directory to which to write temp files.
+  
 ## CREATE USER MAPPING options
 
 There is no user or password conceptions in DuckDB, hence `duckdb_fdw` no need any `CREATE USER MAPPING` command.

--- a/option.c
+++ b/option.c
@@ -70,6 +70,8 @@ static struct SqliteFdwOption valid_options[] =
 	/* batch_size is available on both server and table */
 	{"batch_size", ForeignServerRelationId},
 	{"batch_size", ForeignTableRelationId},
+	/* Optional directory to which to write temp files */
+	{"temp_directory", ForeignServerRelationId},
 	/* Sentinel */
 	{NULL, InvalidOid}
 };
@@ -151,6 +153,10 @@ duckdb_fdw_validator(PG_FUNCTION_ARGS)
 						(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
 						 errmsg("\"%s\" must be an integer value greater than zero",
 								def->defname)));
+		}
+		else if (strcmp(def->defname, "temp_directory") == 0)
+		{
+			defGetString(def);
 		}
 	}
 	PG_RETURN_VOID();

--- a/sqlite3.h
+++ b/sqlite3.h
@@ -3549,6 +3549,13 @@ SQLITE_API int sqlite3_open_v2(
   int flags,              /* Flags */
   const char *zVfs        /* Name of VFS module to use */
 );
+SQLITE_API int sqlite3_open_v3(
+  const char *filename,   /* Database filename (UTF-8) */
+  sqlite3 **ppDb,         /* OUT: SQLite db handle */
+  int flags,              /* Flags */
+  const char *zVfs,       /* Name of VFS module to use */
+  const char *temp_dir    /* Temp directory to use */
+);
 
 /*
 ** CAPI3REF: Obtain Values For URI Parameters

--- a/sqlite3_api_wrapper.cpp
+++ b/sqlite3_api_wrapper.cpp
@@ -152,6 +152,15 @@ int sqlite3_open_v2(const char *filename, /* Database filename (UTF-8) */
                     int flags,            /* Flags */
                     const char *zVfs      /* Name of VFS module to use */
 ) {
+	return sqlite3_open_v3(filename, ppDb, flags, zVfs, NULL);
+}
+
+int sqlite3_open_v3(const char *filename, /* Database filename (UTF-8) */
+                    sqlite3 **ppDb,       /* OUT: SQLite db handle */
+                    int flags,            /* Flags */
+                    const char *zVfs,     /* Name of VFS module to use */
+                    const char *temp_dir  /* Temp directory to use */
+) {
 	if (filename && strcmp(filename, ":memory:") == 0) {
 		filename = NULL;
 	}
@@ -170,6 +179,9 @@ int sqlite3_open_v2(const char *filename, /* Database filename (UTF-8) */
 		}
 		if (flags & DUCKDB_UNSIGNED_EXTENSIONS) {
 			config.options.allow_unsigned_extensions = true;
+		}
+		if (temp_dir) {
+			config.options.temporary_directory = string(temp_dir);
 		}
 		//TODO
 		// config.error_manager->AddCustomError(


### PR DESCRIPTION
This PR adds "temp_directory" option to the `CREATE SERVER` command. It configures the directory where DuckDB writes temp files.

Example:
```sql
CREATE SERVER 
    duckdb_svr 
FOREIGN DATA WRAPPER 
    duckdb_fdw 
OPTIONS (
    database ':memory:', 
    temp_directory '/temp-data'
);
```