### PR TITLE
Updata to use DuckDB v1.0.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM postgres:${POSTGRES_VERSION} AS builder
 
 # Set default values for build arguments
 ARG POSTGRES_VERSION=16
-ARG DUCKDB_VERSION=0.9.2
+ARG DUCKDB_VERSION=1.0.0
 
 # Install build dependencies
 RUN apt-get update && apt-get install -y \

--- a/README.md
+++ b/README.md
@@ -74,11 +74,11 @@ cd duckdb_fdw
 
 #### 2. Download DuckDB library
 
-For example, we want to compile under Linux AMD64 with DuckDB v0.6.1
-just download [libduckdb-linux-amd64.zip](https://github.com/duckdb/duckdb/releases/download/v0.6.1/libduckdb-linux-amd64.zip)
+For example, we want to compile under Linux AMD64 with DuckDB v1.0.0
+just download [libduckdb-linux-amd64.zip](https://github.com/duckdb/duckdb/releases/download/v1.0.0/libduckdb-linux-amd64.zip)
 
 ```bash
-wget -c https://github.com/duckdb/duckdb/releases/download/v0.6.1/libduckdb-linux-amd64.zip
+wget -c https://github.com/duckdb/duckdb/releases/download/v1.0.0/libduckdb-linux-amd64.zip
 unzip -d . libduckdb-linux-amd64.zip
 cp libduckdb.so $(pg_config --libdir) 
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,10 @@
-version: "3.3"
 services:
     duckdb_fdw0:
         build:
             context: .
             args:
                 - POSTGRES_VERSION=16
-                - DUCKDB_VERSION=0.9.2
+                - DUCKDB_VERSION=1.0.0
         ports:
             - "5432:5432"
         volumes:


### PR DESCRIPTION
I built it with docker build and ran it in Docker Desktop.


```
create extension duckdb_fdw;

CREATE SERVER duckdb_server
FOREIGN DATA WRAPPER duckdb_fdw
OPTIONS (database '/tmp/duck.db');

SELECT duckdb_execute('duckdb_server','CREATE TABLE t1_duckdb (a integer, b text);');

CREATE FOREIGN TABLE t1 (
   a integer,
   b text
)
SERVER duckdb_server
OPTIONS (
    table 't1_duckdb'
);

select * from t1; 

insert into t1 values (1,'a');

select * from t1; 

SELECT duckdb_execute('duckdb_server','CREATE TABLE info_ddb as select version() as version;');
CREATE FOREIGN TABLE info_ddb (
   version text
)
SERVER duckdb_server
OPTIONS (
    table 'info_ddb'
);
select version as duckdb_version, duckdb_fdw_version() as duckdb_fdw_version, version() as postgrsql_version from info_ddb;
```

```
duckdb_version:
v1.0.0 

duckdb_fdw_version: 
20101

postgrsql_version:
PostgreSQL 16.3 (Debian 16.3-1.pgdg120+1) on x86_64-pc-linux-gnu, compiled by gcc (Debian 12.2.0-14) 12.2.0, 64-bit

```

