### PR TITLE
change the duckdb_fdw version number to v1.0.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ MODULE_big = duckdb_fdw
 OBJS = connection.o option.o deparse.o sqlite_query.o duckdb_fdw.o sqlite3_api_wrapper.o
 
 EXTENSION = duckdb_fdw
-DATA = duckdb_fdw--1.0.sql duckdb_fdw--1.0--1.1.sql
+DATA = duckdb_fdw--1.0.0.sql
 
 REGRESS = extra/duckdb_fdw_post extra/float4 extra/float8 extra/int4 extra/int8 extra/numeric extra/join extra/limit extra/aggregates extra/prepare extra/select_having extra/select extra/insert extra/update extra/timestamp duckdb_fdw type aggregate selectfunc 
 

--- a/duckdb_fdw.h
+++ b/duckdb_fdw.h
@@ -50,7 +50,7 @@
 #endif
 
 /* Code version is updated at new release. */
-#define CODE_VERSION   20101
+#define CODE_VERSION   10000
 
 #if (PG_VERSION_NUM < 100000)
 /*


### PR DESCRIPTION
- Change the `CODE_VERSION` from `20101` to `10000`
- Change the `DATA` in `Makefile` to use the `duckdb_fdw--1.0.0.sql` only
- Change `duckdb_fdw_version` returning result from `20101` to `10000`
- Fix some typos in the README.md