### PR TITLE
Feature/pg18 windows connection enhancements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ duckdb.h
 duckdb.hpp
 docs/
 .env
+build/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,80 @@
+cmake_minimum_required(VERSION 3.20)
+project(duckdb_fdw LANGUAGES C CXX)
+
+set(CMAKE_C_STANDARD 99)
+set(CMAKE_CXX_STANDARD 11)
+
+# --- 1. Locate PostgreSQL Installation Environment ---
+if(WIN32)
+    set(PG_PATH "C:/Program Files/PostgreSQL/18" CACHE PATH "Path to PostgreSQL installation")
+    
+    include_directories("${PG_PATH}/include/server")
+    include_directories("${PG_PATH}/include/server/port/win32")
+    include_directories("${PG_PATH}/include/server/port/win32_msvc")
+    include_directories("${PG_PATH}/include")
+    link_directories("${PG_PATH}/lib")
+else()
+    find_program(PG_CONFIG pg_config)
+    if(NOT PG_CONFIG)
+        message(FATAL_ERROR "pg_config executable not found. Ensure PostgreSQL binaries are in your PATH.")
+    endif()
+
+    execute_process(COMMAND ${PG_CONFIG} --includedir-server OUTPUT_VARIABLE PG_INCLUDE_SERVER OUTPUT_STRIP_TRAILING_WHITESPACE)
+    execute_process(COMMAND ${PG_CONFIG} --includedir OUTPUT_VARIABLE PG_INCLUDE OUTPUT_STRIP_TRAILING_WHITESPACE)
+    execute_process(COMMAND ${PG_CONFIG} --pkglibdir OUTPUT_VARIABLE PG_PKGLIB OUTPUT_STRIP_TRAILING_WHITESPACE)
+
+    include_directories(${PG_INCLUDE_SERVER} ${PG_INCLUDE})
+    link_directories(${PG_PKGLIB})
+endif()
+
+include_directories(".")
+set(DUCKDB_PATH "${CMAKE_CURRENT_SOURCE_DIR}" CACHE PATH "Path to DuckDB files")
+include_directories(${DUCKDB_PATH})
+link_directories(${DUCKDB_PATH})
+
+# --- 2. Define the Extension Target ---
+set(SOURCE_FILES
+    duckdb_fdw.c
+    connection.c
+    option.c
+    deparse.c
+    nanoarrow.c
+    import.c
+    sql_utils.c
+    runtime_guard.c
+)
+
+add_library(duckdb_fdw SHARED ${SOURCE_FILES})
+
+# --- 3. Target Compiler Definitions and Platform Customization ---
+if(WIN32)
+    target_compile_definitions(duckdb_fdw PRIVATE
+        WIN32
+        _WINDOWS
+        __POINTER_INT_DEFINED
+    )
+    
+    if(MSVC)
+        target_compile_options(duckdb_fdw PRIVATE "/wd4005" "/wd4273")
+    endif()
+
+    target_link_libraries(duckdb_fdw PRIVATE postgres.lib duckdb)
+else()
+    # Explicitly activate GNU extensions needed by runtime_guard.c on Linux
+    target_compile_definitions(duckdb_fdw PRIVATE _GNU_SOURCE)
+    
+    # Safely set CXX standard via target properties to avoid corrupting C files
+    set_target_properties(duckdb_fdw PROPERTIES CXX_STANDARD 11 CXX_STANDARD_REQUIRED ON)
+    
+    target_link_libraries(duckdb_fdw PRIVATE duckdb stdc++)
+
+    if(CMAKE_SYSTEM_NAME MATCHES "Linux")
+        target_link_libraries(duckdb_fdw PRIVATE dl)
+        
+        set_target_properties(duckdb_fdw PROPERTIES 
+            INSTALL_RPATH "$ORIGIN:${PG_PKGLIB}"
+            BUILD_WITH_INSTALL_RPATH TRUE
+        )
+    endif()
+    set_target_properties(duckdb_fdw PROPERTIES PREFIX "")
+endif()

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+# Maybe obsolete. Use cmake
 #-------------------------------------------------------------------------
 #
 # DuckDB Foreign Data Wrapper for PostgreSQL
@@ -36,7 +37,7 @@ ifeq ($(detected_OS),Linux)
     DLSUFFIX = .so
     PG_CXXFLAGS = -std=c++11
     # 针对现代环境的 ABI 兼容性设置
-    PG_CPPFLAGS += -D_GLIBCXX_USE_CXX11_ABI=0
+    #PG_CPPFLAGS += -D_GLIBCXX_USE_CXX11_ABI=0
     SHLIB_LINK += -ldl
 endif
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Postgres](https://img.shields.io/badge/PostgreSQL-13--18-blue.svg)](https://www.postgresql.org/)
 [![DuckDB](https://img.shields.io/badge/DuckDB-1.x-orange.svg)](https://duckdb.org/)
 
-**`duckdb_fdw`** v2.0+ is a high-performance PostgreSQL extension that bridges PostgreSQL's ecosystem with DuckDB's vectorized analytical power. Built natively on the **DuckDB C API**, it supports modern Lakehouse workflows including Parquet, Iceberg, S3 Tables, DuckLake, MotherDuck, and the Quack client-server protocol.
+**`duckdb_fdw`** v2.0+ is a high-performance PostgreSQL extension that bridges PostgreSQL's ecosystem with DuckDB's vectorized analytical power. Built natively on the **DuckDB C API**, it supports modern Lakehouse workflows including Parquet, Iceberg, S3 Tables, DuckLake, MotherDuck, and the Quack client-server protocol. PostgreSQL 13-18 are supported, and the project now includes a CMake-based build path for Windows deployments.[file:1]
 
 ---
 
@@ -21,7 +21,8 @@
 | MotherDuck integration | Implemented | `motherduck_token` option + auto-extension loading | MotherDuck account |
 | Quack client-server protocol | Implemented | via `extensions 'quack'` + `duckdb_execute` | DuckDB with Quack extension |
 | Runtime coexistence guard for `pg_duckdb` | Implemented (Linux-first) | `runtime_guard.c`, `scripts/verify_pg_duckdb_coexistence.sh` | Same-backend peer detection |
-| Iceberg/S3 examples | Partial | `examples/07-13` | Network, optional credentials |
+| Windows build and deployment path | Implemented | `CMakeLists.txt`, `install_duckdb_fdw.ps1` | PostgreSQL for Windows, CMake |
+| Import foreign schema for tables and views | Implemented | `import.c` | Remote schema with objects |
 | Full Arrow C Data scan path | Planned | no `duckdb_query_arrow` call in active scan path; tracked as future work | future release |
 
 ## 🧪 Test Profiles
@@ -61,23 +62,66 @@ make
 sudo make install
 ```
 
+### Quick Build (Windows)
+
+On Windows, `duckdb_fdw` can be built as a DLL with CMake and deployed into a local PostgreSQL installation with the included PowerShell helper.
+
+```powershell
+# 1. Download DuckDB headers and library
+# Run this from Git Bash, MSYS2, or WSL
+./download_libduckdb.sh
+
+# 2. Configure and build from a Developer Command Prompt or terminal with MSVC/Ninja available
+cmake -S . -B build -G "Ninja" -DCMAKE_BUILD_TYPE=Release
+cmake --build build --config Release
+
+# 3. Install into PostgreSQL
+.\install_duckdb_fdw.ps1 -PostgresBase "C:\Program Files\PostgreSQL\18"
+```
+
+The PowerShell installer copies:
+
+- `duckdb_fdw.dll` into `<PostgresBase>\lib`
+- `duckdb_fdw.control` and `duckdb_fdw--*.sql` into `<PostgresBase>\share\extension`
+- `duckdb.dll` into `<PostgresBase>\bin` when present
+
+### Scripted Install (Linux)
+
+If you build with CMake/Ninja instead of PGXS, use the Linux deployment helper to install the generated artifacts into the PostgreSQL extension directories resolved from `pg_config`.
+
+```bash
+cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Release
+cmake --build build
+sudo ./install_duckdb_fdw.sh
+```
+
+You can also override the target paths explicitly:
+
+```bash
+sudo ./install_duckdb_fdw.sh \
+  --pg-lib /usr/lib/postgresql/18/lib \
+  --pg-ext /usr/share/postgresql/18/extension
+```
+
 ### Requirements
-* PostgreSQL 13 - 18 (headers required)
-* DuckDB library (`libduckdb.so` or `libduckdb.dylib`) with repo-pinned bootstrap default `1.5.1`
-* GCC or Clang with C11/C++11 support
+
+- PostgreSQL 13 - 18 (headers required)
+- DuckDB shared library (`libduckdb.so`, `libduckdb.dylib`, or `duckdb.dll`) with repo-pinned bootstrap default `1.5.1`
+- GCC or Clang with C11/C++11 support on Unix-like systems, or MSVC-compatible CMake toolchain on Windows
 
 ## 🛠️ Usage
 
 ### 1. Initialize
+
 ```sql
 CREATE EXTENSION duckdb_fdw;
 
-CREATE SERVER duckdb_srv 
-FOREIGN DATA WRAPPER duckdb_fdw 
+CREATE SERVER duckdb_srv
+FOREIGN DATA WRAPPER duckdb_fdw
 OPTIONS (database '/tmp/duckdb_fdw_demo.db');
 ```
 
-`database ':memory:'` is a connection-scoped temporary database. `duckdb_fdw` now refreshes cached connections at transaction end, so if you create tables or views with `duckdb_execute(...)` and then read them through foreign tables in later SQL statements, use a file-backed DuckDB database by default. If you intentionally want `:memory:`, wrap the entire modeling and query sequence in the same explicit transaction.
+`database ':memory:'` is a connection-scoped temporary database. `duckdb_fdw` refreshes cached connections at transaction end, so if you create tables or views with `duckdb_execute(...)` and then read them through foreign tables in later SQL statements, use a file-backed DuckDB database by default. If you intentionally want `:memory:`, wrap the entire modeling and query sequence in the same explicit transaction.[file:1]
 
 ### 2. `pg_duckdb` Coexistence Policy
 
@@ -103,7 +147,9 @@ LOAD 'duckdb_fdw';
 SET duckdb_fdw.allow_unsupported_pg_duckdb_coexistence = on;
 ```
 
-This override is explicitly outside the supported public contract. It is off by default, does not allow preload placeholders, and cannot be hidden inside a transaction with `SET LOCAL`.
+This override is explicitly outside the supported public contract. It is off by default, does not allow preload placeholders, and cannot be hidden inside a transaction with `SET LOCAL`.[file:1]
+
+On Windows, the extension currently enables the unsupported coexistence override during `_PG_init()` to simplify DLL loading scenarios. This should still be treated as platform-specific compatibility behavior rather than a supported coexistence guarantee.
 
 Linux-first coexistence verification script:
 
@@ -115,11 +161,14 @@ Linux-first coexistence verification script:
 
 #### S3 (Recommended: USER MAPPING)
 
-For security, prefer storing S3 credentials in **USER MAPPING** rather than server options. `pg_foreign_server` options are public-readable by default; `USER MAPPING` credentials are only visible to the mapped user and superusers.
+For security, prefer storing S3 credentials in **USER MAPPING** rather than server options. `pg_foreign_server` options are public-readable by default; `USER MAPPING` credentials are only visible to the mapped user and superusers.[file:1]
 
 ```sql
-CREATE SERVER s3_srv FOREIGN DATA WRAPPER duckdb_fdw 
-OPTIONS (database '/tmp/s3_cache.db', s3_region 'us-east-1');
+CREATE SERVER s3_srv FOREIGN DATA WRAPPER duckdb_fdw
+OPTIONS (
+    database '/tmp/s3_cache.db',
+    s3_region 'us-east-1'
+);
 
 -- Secure: credentials in USER MAPPING (not visible to other users)
 CREATE USER MAPPING FOR current_user SERVER s3_srv
@@ -140,20 +189,55 @@ CREATE SERVER s3_srv FOREIGN DATA WRAPPER duckdb_fdw OPTIONS (
 );
 ```
 
+#### S3 URL Style
+
+Some S3-compatible endpoints require explicit path-style or virtual-host-style access. Use `s3_url_style` to control that behavior.
+
+```sql
+CREATE SERVER s3_srv FOREIGN DATA WRAPPER duckdb_fdw OPTIONS (
+    database '/tmp/s3_cache.db',
+    s3_region 'us-east-1',
+    s3_endpoint 'https://minio.local:9000',
+    s3_url_style 'path'
+);
+```
+
+Supported values are typically `path` or `vhost`, depending on the target object store.
+
 #### Secret Helper Function
 
 ```sql
 SELECT duckdb_create_s3_secret('s3_srv', 'my_s3_key', 'YOUR_KEY', 'YOUR_SECRET', 'us-east-1');
 ```
 
-### 4. Query Data Lake (Parquet / Iceberg / DuckLake)
+### 4. Connection Initialization Options
+
+`duckdb_fdw` supports server-level connection options for read-only access and custom initialization SQL.
+
+```sql
+CREATE SERVER duckdb_ro_srv
+FOREIGN DATA WRAPPER duckdb_fdw
+OPTIONS (
+    database '/tmp/analytics.db',
+    read_only 'true',
+    init_sql $$
+      INSTALL httpfs;
+      LOAD httpfs;
+    $$
+);
+```
+
+- `read_only`: opens the DuckDB database using `access_mode=read_only`
+- `init_sql`: executes arbitrary DuckDB SQL after the connection is established; useful for `INSTALL`, `LOAD`, or session settings
+
+### 5. Query Data Lake (Parquet / Iceberg / DuckLake)
 
 ```sql
 -- Direct scan of S3 Parquet
 CREATE FOREIGN TABLE s3_data (
     id INT,
     price DECIMAL
-) SERVER s3_srv 
+) SERVER s3_srv
 OPTIONS (table 's3://my-bucket/data.parquet');
 
 -- Import whole DuckLake or Iceberg schema
@@ -161,7 +245,7 @@ CREATE SCHEMA remote_tpch;
 IMPORT FOREIGN SCHEMA "tpch" FROM SERVER s3_srv INTO remote_tpch;
 ```
 
-**DuckLake** catalogs (`type=ducklake`) are auto-detected. Just point `attach_catalogs` at a DuckLake URL and duckdb_fdw automatically loads the Iceberg extension:
+**DuckLake** catalogs (`type=ducklake`) are auto-detected. Just point `attach_catalogs` at a DuckLake URL and `duckdb_fdw` automatically loads the Iceberg extension.[file:1]
 
 ```sql
 CREATE SERVER ducklake_srv FOREIGN DATA WRAPPER duckdb_fdw OPTIONS (
@@ -172,30 +256,26 @@ CREATE SERVER ducklake_srv FOREIGN DATA WRAPPER duckdb_fdw OPTIONS (
 IMPORT FOREIGN SCHEMA "tpch" FROM SERVER ducklake_srv INTO public;
 ```
 
-### 5. High-Speed S3 Tables (Lakehouse)
+### 6. High-Speed S3 Tables (Lakehouse)
 
-`duckdb_fdw` v2.0+ handles **AWS S3 Tables** with zero configuration. It automatically detects `arn:aws:s3tables` URIs and injects the required `sigv4` authorization.
+`duckdb_fdw` v2.0+ handles **AWS S3 Tables** with zero configuration. It automatically detects `arn:aws:s3tables` URIs and injects the required `sigv4` authorization.[file:1]
 
 ```sql
 CREATE SERVER lakehouse_srv FOREIGN DATA WRAPPER duckdb_fdw OPTIONS (
     database '/tmp/duckdb_fdw_lakehouse.db',
     s3_region 'us-east-1',
-    -- Attach S3 Table catalog (endpoint and auth are auto-injected)
     attach_catalogs 'my_res=arn:aws:s3tables:us-east-1:12345678:bucket/my-table;type iceberg'
 );
 
--- Automated schema discovery using DESCRIBE
 IMPORT FOREIGN SCHEMA "my_res" FROM SERVER lakehouse_srv INTO public;
-
--- Query natively with predicate pushdown
 SELECT * FROM part WHERE p_partkey = 1;
 ```
 
-### 6. MotherDuck
+### 7. MotherDuck
 
 > Requires: DuckDB >= 1.1 with `motherduck` extension available.
 
-Set your MotherDuck token in **USER MAPPING** (recommended for security) or server options. The extension is auto-installed and a MotherDuck SECRET is created automatically on connection.
+Set your MotherDuck token in **USER MAPPING** (recommended for security) or server options. The extension is auto-installed and a MotherDuck SECRET is created automatically on connection.[file:1]
 
 ```sql
 CREATE SERVER md_srv FOREIGN DATA WRAPPER duckdb_fdw
@@ -214,7 +294,7 @@ IMPORT FOREIGN SCHEMA "my_md" FROM SERVER md_srv INTO public;
 SELECT duckdb_execute('md_srv', 'CREATE TABLE my_md.my_table AS SELECT 42 AS answer');
 ```
 
-You can also reference MotherDuck databases via `attach_catalogs`:
+You can also reference MotherDuck databases via `attach_catalogs`:[file:1]
 
 ```sql
 CREATE SERVER md_catalog_srv FOREIGN DATA WRAPPER duckdb_fdw OPTIONS (
@@ -226,48 +306,53 @@ CREATE SERVER md_catalog_srv FOREIGN DATA WRAPPER duckdb_fdw OPTIONS (
 IMPORT FOREIGN SCHEMA "my_db" FROM SERVER md_catalog_srv INTO public;
 ```
 
-### 7. Quack (Client-Server + Multi-Client Concurrent Writes)
+### 8. Quack (Client-Server + Multi-Client Concurrent Writes)
 
 > Requires: DuckDB >= 1.5.2 with `quack` extension available. See [Quack documentation](https://duckdb.org/quack/).
 
-Quack is DuckDB's native client-server protocol. duckdb_fdw supports it in two modes:
+Quack is DuckDB's native client-server protocol. `duckdb_fdw` supports it in two modes.[file:1]
 
 #### Start the Quack Server
-
-Spin up a Quack server from any DuckDB database:
 
 ```bash
 duckdb /path/to/shared.db -cmd "LOAD quack; SELECT * FROM quack_serve('quack://0.0.0.0:9494', token := 'shared_secret', allow_other_hostname := true);"
 ```
 
-> **Prerequisite**: The PostgreSQL process needs a writable DuckDB home directory (`$HOME/.duckdb/`) to cache extensions. If you see "Can't find the home directory at ''", either set `HOME` in the PG service (`systemctl edit postgresql` → `Environment=HOME=/var/lib/postgresql`) or use Manual Mode with a pre-created database file.
+> **Prerequisite**: The PostgreSQL process needs a writable DuckDB home directory (`$HOME/.duckdb/`) to cache extensions. If you see `Can't find the home directory at ''`, either set `HOME` in the PG service (`systemctl edit postgresql` → `Environment=HOME=/var/lib/postgresql`) or use Manual Mode with a pre-created database file.[file:1]
 
 #### Native Proxy Mode (Recommended)
 
-Set `quack_host` in the server options. duckdb_fdw automatically opens a local in-memory DuckDB, loads the Quack extension, creates a Quack SECRET, and ATTACHes the remote server. All foreign tables are created as `remote.schema.table` — queries are transparently routed to the Quack server.
+Set `quack_host` in the server options. `duckdb_fdw` automatically opens a local in-memory DuckDB, loads the Quack extension, creates a Quack SECRET, and `ATTACH`es the remote server. All foreign tables are created as `remote.schema.table`, so queries are transparently routed to the Quack server.[file:1]
 
 ```sql
--- Point to the Quack server
 CREATE SERVER quack_srv FOREIGN DATA WRAPPER duckdb_fdw
 OPTIONS (quack_host '192.168.1.10:9494');
 
--- Token in USER MAPPING (secure)
 CREATE USER MAPPING FOR current_user SERVER quack_srv
 OPTIONS (quack_token 'shared_secret');
 
--- One command: import all remote tables
 IMPORT FOREIGN SCHEMA main FROM SERVER quack_srv INTO public;
-
--- Query remote data through standard PG SQL
 SELECT * FROM orders WHERE amount > 1000;
 INSERT INTO orders VALUES (1, 99.9, '2026-05-29');
 ```
 
-This mode solves the classic DuckDB concurrency problem: **multiple PG backends can concurrently read and write the same DuckDB database** through a single Quack server process. All PG clients share one `.duckdb` file without lock conflicts.
+This mode solves the classic DuckDB concurrency problem: **multiple PG backends can concurrently read and write the same DuckDB database** through a single Quack server process. All PG clients share one `.duckdb` file without lock conflicts.[file:1]
+
+You can additionally disable TLS in Quack proxy mode when the deployment environment requires it:
+
+```sql
+CREATE SERVER quack_insecure_srv FOREIGN DATA WRAPPER duckdb_fdw
+OPTIONS (
+    quack_host '192.168.1.10:9494',
+    disable_ssl 'true'
+);
+```
+
+`IMPORT FOREIGN SCHEMA` now discovers both base tables and views through `information_schema.tables`. In Quack proxy mode, discovery and import resolution are performed using `remote.query(...)` and `remote.schema.table` references.
 
 #### Manual Mode
 
-For more control, use `duckdb_execute` to manage the Quack connection yourself. This mode also works around the home directory issue on machines where the PG process can't set `$HOME`:
+For more control, use `duckdb_execute` to manage the Quack connection yourself. This mode also works around the home directory issue on machines where the PG process cannot set `HOME`.[file:1]
 
 ```sql
 CREATE SERVER quack_srv FOREIGN DATA WRAPPER duckdb_fdw
@@ -279,16 +364,16 @@ SELECT duckdb_execute('quack_srv',
     ATTACH 'quack:remote-host:9494' AS remote_db;$$);
 ```
 
-### 8. Arbitrary DuckDB SQL
+### 9. Arbitrary DuckDB SQL
 
-The `duckdb_execute()` function lets you run any DuckDB SQL through the FDW connection — useful for DDL, extension management, or one-off operations:
+The `duckdb_execute()` function lets you run any DuckDB SQL through the FDW connection, which is useful for DDL, extension management, or one-off operations.[file:1]
 
 ```sql
 SELECT duckdb_execute('duckdb_srv', 'CREATE TABLE tmp AS SELECT range AS id FROM range(1000)');
 SELECT duckdb_execute('duckdb_srv', 'INSTALL spatial; LOAD spatial;');
 ```
 
-Result messages containing credentials (SECRET, KEY_ID, ACCESS_KEY, TOKEN, motherduck) are automatically redacted in error output for security.
+Result messages containing credentials (`SECRET`, `KEY_ID`, `ACCESS_KEY`, `TOKEN`, `motherduck`) are automatically redacted in error output for security.[file:1]
 
 ## 📉 Feature Comparison
 
@@ -301,6 +386,7 @@ Result messages containing credentials (SECRET, KEY_ID, ACCESS_KEY, TOKEN, mothe
 | **Performance** | Basic | **Filter & Limit Pushdown** |
 | **MotherDuck** | ❌ | ✅ Auto-extension + token management |
 | **Quack** | ❌ | ✅ via `extensions 'quack'` (zero code changes) |
+| **Windows build path** | ❌ | ✅ via CMake + PowerShell installer |
 
 ## 🦆 How is this different from `pg_duckdb`?
 
@@ -312,21 +398,21 @@ Result messages containing credentials (SECRET, KEY_ID, ACCESS_KEY, TOKEN, mothe
 | **Data lake access** | FOREIGN TABLE + IMPORT FOREIGN SCHEMA | `read_parquet()` DuckDB functions |
 | **Learning curve** | Standard PG SQL | DuckDB-specific syntax for data lake functions |
 | **Codebase** | ~6,500 lines C | ~81,000 lines C++ |
-| **Can they coexist?** | Not in the same backend (both link `libduckdb.so`) | — |
+| **Can they coexist?** | Not in the same backend on Linux; Windows behavior is compatibility-oriented but unsupported | — |
 
-**They solve different problems.** `pg_duckdb` asks "how can DuckDB make PostgreSQL faster?" `duckdb_fdw` asks "how can PostgreSQL users access everything DuckDB can read?" If you need both, run them on separate PG instances.
+**They solve different problems.** `pg_duckdb` asks "how can DuckDB make PostgreSQL faster?" `duckdb_fdw` asks "how can PostgreSQL users access everything DuckDB can read?" If you need both, run them on separate PG instances.[file:1]
 
 ## 🤝 Contributing
 
-Contributions are welcome. Current high-priority areas are production hardening, deterministic regression coverage, and eventually a true Arrow C Data read path.
+Contributions are welcome. Current high-priority areas are production hardening, deterministic regression coverage, improved Windows CI validation, and eventually a true Arrow C Data read path.[file:1]
 
 ## 🔧 Troubleshooting
 
 ### "Can't find the home directory at ''" (Quack mode)
 
-DuckDB 1.5+ needs a writable `$HOME/.duckdb/` to cache extensions. The PG backend runs as the `postgres` user, which may not have `$HOME` set.
+DuckDB 1.5+ needs a writable `$HOME/.duckdb/` to cache extensions. The PG backend runs as the `postgres` user, which may not have `HOME` set.[file:1]
 
-**Fix A**: Set HOME in the PG service:
+**Fix A**: Set `HOME` in the PG service:
 
 ```bash
 sudo systemctl edit postgresql
@@ -334,7 +420,7 @@ sudo systemctl edit postgresql
 sudo systemctl restart postgresql
 ```
 
-**Fix B**: Use Manual Mode with a pre-created DB file (bypasses in-memory DuckDB):
+**Fix B**: Use Manual Mode with a pre-created DB file (bypasses in-memory DuckDB):[file:1]
 
 ```sql
 CREATE SERVER quack_srv FOREIGN DATA WRAPPER duckdb_fdw
@@ -343,7 +429,11 @@ OPTIONS (database '/tmp/quack_fdw.db', extensions 'quack');
 
 ### Compilation error: "implicit declaration of function 'GetUserId'" (PG 17)
 
-PostgreSQL 17 requires explicit `#include "miscadmin.h"` for `GetUserId()`. This is fixed in the main branch — make sure you're on the latest commit.
+PostgreSQL 17 requires explicit `#include "miscadmin.h"` for `GetUserId()`. This is fixed in the main branch, so ensure the checkout includes the PG17 compatibility fix already present upstream.[file:1]
+
+### PostgreSQL 18 build errors around `create_foreignscan_path`
+
+PostgreSQL 18 changed the `create_foreignscan_path` signature to include the `disabled_nodes` argument. The extension now handles this with version guards, so verify that the build includes the PG18 compatibility changes before compiling.
 
 ### Downloading libduckdb times out (GitHub behind proxy)
 
@@ -351,6 +441,10 @@ PostgreSQL 17 requires explicit `#include "miscadmin.h"` for `GetUserId()`. This
 export HTTP_PROXY=http://your-proxy:port HTTPS_PROXY=http://your-proxy:port
 ./download_libduckdb.sh
 ```
+
+### ARM64 release asset naming mismatch
+
+The DuckDB release asset download helper resolves Linux ARM64 builds using the `arm64` artifact suffix. If downloads fail on `aarch64`/`arm64`, verify that the script is up to date and targets the expected DuckDB release naming.
 
 ## 📄 License
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Postgres](https://img.shields.io/badge/PostgreSQL-13--18-blue.svg)](https://www.postgresql.org/)
 [![DuckDB](https://img.shields.io/badge/DuckDB-1.x-orange.svg)](https://duckdb.org/)
 
-**`duckdb_fdw`** v2.0+ is a high-performance PostgreSQL extension that bridges PostgreSQL's ecosystem with DuckDB's vectorized analytical power. Built natively on the **DuckDB C API**, it supports modern Lakehouse workflows including Parquet, Iceberg, S3 Tables, DuckLake, MotherDuck, and the Quack client-server protocol. PostgreSQL 13-18 are supported, and the project now includes a CMake-based build path for Windows deployments.[file:1]
+**`duckdb_fdw`** v2.0+ is a high-performance PostgreSQL extension that bridges PostgreSQL's ecosystem with DuckDB's vectorized analytical power. Built natively on the **DuckDB C API**, it supports modern Lakehouse workflows including Parquet, Iceberg, S3 Tables, DuckLake, MotherDuck, and the Quack client-server protocol. PostgreSQL 13-18 are supported, and the project now includes a CMake-based build path for Windows deployments.
 
 ---
 
@@ -62,21 +62,25 @@ make
 sudo make install
 ```
 
-### Quick Build (Windows)
+### Quick Build Windows (Also works for Linux)
 
 On Windows, `duckdb_fdw` can be built as a DLL with CMake and deployed into a local PostgreSQL installation with the included PowerShell helper.
 
 ```powershell
 # 1. Download DuckDB headers and library
 # Run this from Git Bash, MSYS2, or WSL
+.\download_libduckdb.ps1
+or
 ./download_libduckdb.sh
 
 # 2. Configure and build from a Developer Command Prompt or terminal with MSVC/Ninja available
-cmake -S . -B build -G "Ninja" -DCMAKE_BUILD_TYPE=Release
-cmake --build build --config Release
+cmake -G "Ninja" -DCMAKE_BUILD_TYPE=Release ..
+cmake --build . --config Release
 
 # 3. Install into PostgreSQL
 .\install_duckdb_fdw.ps1 -PostgresBase "C:\Program Files\PostgreSQL\18"
+or
+./install_duckdb_fdw.sh
 ```
 
 The PowerShell installer copies:
@@ -121,7 +125,7 @@ FOREIGN DATA WRAPPER duckdb_fdw
 OPTIONS (database '/tmp/duckdb_fdw_demo.db');
 ```
 
-`database ':memory:'` is a connection-scoped temporary database. `duckdb_fdw` refreshes cached connections at transaction end, so if you create tables or views with `duckdb_execute(...)` and then read them through foreign tables in later SQL statements, use a file-backed DuckDB database by default. If you intentionally want `:memory:`, wrap the entire modeling and query sequence in the same explicit transaction.[file:1]
+`database ':memory:'` is a connection-scoped temporary database. `duckdb_fdw` refreshes cached connections at transaction end, so if you create tables or views with `duckdb_execute(...)` and then read them through foreign tables in later SQL statements, use a file-backed DuckDB database by default. If you intentionally want `:memory:`, wrap the entire modeling and query sequence in the same explicit transaction.
 
 ### 2. `pg_duckdb` Coexistence Policy
 
@@ -147,7 +151,7 @@ LOAD 'duckdb_fdw';
 SET duckdb_fdw.allow_unsupported_pg_duckdb_coexistence = on;
 ```
 
-This override is explicitly outside the supported public contract. It is off by default, does not allow preload placeholders, and cannot be hidden inside a transaction with `SET LOCAL`.[file:1]
+This override is explicitly outside the supported public contract. It is off by default, does not allow preload placeholders, and cannot be hidden inside a transaction with `SET LOCAL`.
 
 On Windows, the extension currently enables the unsupported coexistence override during `_PG_init()` to simplify DLL loading scenarios. This should still be treated as platform-specific compatibility behavior rather than a supported coexistence guarantee.
 
@@ -161,7 +165,7 @@ Linux-first coexistence verification script:
 
 #### S3 (Recommended: USER MAPPING)
 
-For security, prefer storing S3 credentials in **USER MAPPING** rather than server options. `pg_foreign_server` options are public-readable by default; `USER MAPPING` credentials are only visible to the mapped user and superusers.[file:1]
+For security, prefer storing S3 credentials in **USER MAPPING** rather than server options. `pg_foreign_server` options are public-readable by default; `USER MAPPING` credentials are only visible to the mapped user and superusers.
 
 ```sql
 CREATE SERVER s3_srv FOREIGN DATA WRAPPER duckdb_fdw
@@ -245,7 +249,7 @@ CREATE SCHEMA remote_tpch;
 IMPORT FOREIGN SCHEMA "tpch" FROM SERVER s3_srv INTO remote_tpch;
 ```
 
-**DuckLake** catalogs (`type=ducklake`) are auto-detected. Just point `attach_catalogs` at a DuckLake URL and `duckdb_fdw` automatically loads the Iceberg extension.[file:1]
+**DuckLake** catalogs (`type=ducklake`) are auto-detected. Just point `attach_catalogs` at a DuckLake URL and `duckdb_fdw` automatically loads the Iceberg extension.
 
 ```sql
 CREATE SERVER ducklake_srv FOREIGN DATA WRAPPER duckdb_fdw OPTIONS (
@@ -258,7 +262,7 @@ IMPORT FOREIGN SCHEMA "tpch" FROM SERVER ducklake_srv INTO public;
 
 ### 6. High-Speed S3 Tables (Lakehouse)
 
-`duckdb_fdw` v2.0+ handles **AWS S3 Tables** with zero configuration. It automatically detects `arn:aws:s3tables` URIs and injects the required `sigv4` authorization.[file:1]
+`duckdb_fdw` v2.0+ handles **AWS S3 Tables** with zero configuration. It automatically detects `arn:aws:s3tables` URIs and injects the required `sigv4` authorization.
 
 ```sql
 CREATE SERVER lakehouse_srv FOREIGN DATA WRAPPER duckdb_fdw OPTIONS (
@@ -275,7 +279,7 @@ SELECT * FROM part WHERE p_partkey = 1;
 
 > Requires: DuckDB >= 1.1 with `motherduck` extension available.
 
-Set your MotherDuck token in **USER MAPPING** (recommended for security) or server options. The extension is auto-installed and a MotherDuck SECRET is created automatically on connection.[file:1]
+Set your MotherDuck token in **USER MAPPING** (recommended for security) or server options. The extension is auto-installed and a MotherDuck SECRET is created automatically on connection.
 
 ```sql
 CREATE SERVER md_srv FOREIGN DATA WRAPPER duckdb_fdw
@@ -294,7 +298,7 @@ IMPORT FOREIGN SCHEMA "my_md" FROM SERVER md_srv INTO public;
 SELECT duckdb_execute('md_srv', 'CREATE TABLE my_md.my_table AS SELECT 42 AS answer');
 ```
 
-You can also reference MotherDuck databases via `attach_catalogs`:[file:1]
+You can also reference MotherDuck databases via `attach_catalogs`:
 
 ```sql
 CREATE SERVER md_catalog_srv FOREIGN DATA WRAPPER duckdb_fdw OPTIONS (
@@ -310,7 +314,7 @@ IMPORT FOREIGN SCHEMA "my_db" FROM SERVER md_catalog_srv INTO public;
 
 > Requires: DuckDB >= 1.5.2 with `quack` extension available. See [Quack documentation](https://duckdb.org/quack/).
 
-Quack is DuckDB's native client-server protocol. `duckdb_fdw` supports it in two modes.[file:1]
+Quack is DuckDB's native client-server protocol. `duckdb_fdw` supports it in two modes.
 
 #### Start the Quack Server
 
@@ -318,11 +322,11 @@ Quack is DuckDB's native client-server protocol. `duckdb_fdw` supports it in two
 duckdb /path/to/shared.db -cmd "LOAD quack; SELECT * FROM quack_serve('quack://0.0.0.0:9494', token := 'shared_secret', allow_other_hostname := true);"
 ```
 
-> **Prerequisite**: The PostgreSQL process needs a writable DuckDB home directory (`$HOME/.duckdb/`) to cache extensions. If you see `Can't find the home directory at ''`, either set `HOME` in the PG service (`systemctl edit postgresql` → `Environment=HOME=/var/lib/postgresql`) or use Manual Mode with a pre-created database file.[file:1]
+> **Prerequisite**: The PostgreSQL process needs a writable DuckDB home directory (`$HOME/.duckdb/`) to cache extensions. If you see `Can't find the home directory at ''`, either set `HOME` in the PG service (`systemctl edit postgresql` → `Environment=HOME=/var/lib/postgresql`) or use Manual Mode with a pre-created database file.
 
 #### Native Proxy Mode (Recommended)
 
-Set `quack_host` in the server options. `duckdb_fdw` automatically opens a local in-memory DuckDB, loads the Quack extension, creates a Quack SECRET, and `ATTACH`es the remote server. All foreign tables are created as `remote.schema.table`, so queries are transparently routed to the Quack server.[file:1]
+Set `quack_host` in the server options. `duckdb_fdw` automatically opens a local in-memory DuckDB, loads the Quack extension, creates a Quack SECRET, and `ATTACH`es the remote server. All foreign tables are created as `remote.schema.table`, so queries are transparently routed to the Quack server.
 
 ```sql
 CREATE SERVER quack_srv FOREIGN DATA WRAPPER duckdb_fdw
@@ -336,7 +340,7 @@ SELECT * FROM orders WHERE amount > 1000;
 INSERT INTO orders VALUES (1, 99.9, '2026-05-29');
 ```
 
-This mode solves the classic DuckDB concurrency problem: **multiple PG backends can concurrently read and write the same DuckDB database** through a single Quack server process. All PG clients share one `.duckdb` file without lock conflicts.[file:1]
+This mode solves the classic DuckDB concurrency problem: **multiple PG backends can concurrently read and write the same DuckDB database** through a single Quack server process. All PG clients share one `.duckdb` file without lock conflicts.
 
 You can additionally disable TLS in Quack proxy mode when the deployment environment requires it:
 
@@ -352,7 +356,7 @@ OPTIONS (
 
 #### Manual Mode
 
-For more control, use `duckdb_execute` to manage the Quack connection yourself. This mode also works around the home directory issue on machines where the PG process cannot set `HOME`.[file:1]
+For more control, use `duckdb_execute` to manage the Quack connection yourself. This mode also works around the home directory issue on machines where the PG process cannot set `HOME`.
 
 ```sql
 CREATE SERVER quack_srv FOREIGN DATA WRAPPER duckdb_fdw
@@ -366,14 +370,14 @@ SELECT duckdb_execute('quack_srv',
 
 ### 9. Arbitrary DuckDB SQL
 
-The `duckdb_execute()` function lets you run any DuckDB SQL through the FDW connection, which is useful for DDL, extension management, or one-off operations.[file:1]
+The `duckdb_execute()` function lets you run any DuckDB SQL through the FDW connection, which is useful for DDL, extension management, or one-off operations.
 
 ```sql
 SELECT duckdb_execute('duckdb_srv', 'CREATE TABLE tmp AS SELECT range AS id FROM range(1000)');
 SELECT duckdb_execute('duckdb_srv', 'INSTALL spatial; LOAD spatial;');
 ```
 
-Result messages containing credentials (`SECRET`, `KEY_ID`, `ACCESS_KEY`, `TOKEN`, `motherduck`) are automatically redacted in error output for security.[file:1]
+Result messages containing credentials (`SECRET`, `KEY_ID`, `ACCESS_KEY`, `TOKEN`, `motherduck`) are automatically redacted in error output for security.
 
 ## 📉 Feature Comparison
 
@@ -400,17 +404,17 @@ Result messages containing credentials (`SECRET`, `KEY_ID`, `ACCESS_KEY`, `TOKEN
 | **Codebase** | ~6,500 lines C | ~81,000 lines C++ |
 | **Can they coexist?** | Not in the same backend on Linux; Windows behavior is compatibility-oriented but unsupported | — |
 
-**They solve different problems.** `pg_duckdb` asks "how can DuckDB make PostgreSQL faster?" `duckdb_fdw` asks "how can PostgreSQL users access everything DuckDB can read?" If you need both, run them on separate PG instances.[file:1]
+**They solve different problems.** `pg_duckdb` asks "how can DuckDB make PostgreSQL faster?" `duckdb_fdw` asks "how can PostgreSQL users access everything DuckDB can read?" If you need both, run them on separate PG instances.
 
 ## 🤝 Contributing
 
-Contributions are welcome. Current high-priority areas are production hardening, deterministic regression coverage, improved Windows CI validation, and eventually a true Arrow C Data read path.[file:1]
+Contributions are welcome. Current high-priority areas are production hardening, deterministic regression coverage, improved Windows CI validation, and eventually a true Arrow C Data read path.
 
 ## 🔧 Troubleshooting
 
 ### "Can't find the home directory at ''" (Quack mode)
 
-DuckDB 1.5+ needs a writable `$HOME/.duckdb/` to cache extensions. The PG backend runs as the `postgres` user, which may not have `HOME` set.[file:1]
+DuckDB 1.5+ needs a writable `$HOME/.duckdb/` to cache extensions. The PG backend runs as the `postgres` user, which may not have `HOME` set.
 
 **Fix A**: Set `HOME` in the PG service:
 
@@ -420,7 +424,7 @@ sudo systemctl edit postgresql
 sudo systemctl restart postgresql
 ```
 
-**Fix B**: Use Manual Mode with a pre-created DB file (bypasses in-memory DuckDB):[file:1]
+**Fix B**: Use Manual Mode with a pre-created DB file (bypasses in-memory DuckDB):
 
 ```sql
 CREATE SERVER quack_srv FOREIGN DATA WRAPPER duckdb_fdw
@@ -429,7 +433,7 @@ OPTIONS (database '/tmp/quack_fdw.db', extensions 'quack');
 
 ### Compilation error: "implicit declaration of function 'GetUserId'" (PG 17)
 
-PostgreSQL 17 requires explicit `#include "miscadmin.h"` for `GetUserId()`. This is fixed in the main branch, so ensure the checkout includes the PG17 compatibility fix already present upstream.[file:1]
+PostgreSQL 17 requires explicit `#include "miscadmin.h"` for `GetUserId()`. This is fixed in the main branch, so ensure the checkout includes the PG17 compatibility fix already present upstream.
 
 ### PostgreSQL 18 build errors around `create_foreignscan_path`
 

--- a/README.md
+++ b/README.md
@@ -74,10 +74,13 @@ or
 ./download_libduckdb.sh
 
 # 2. Configure and build from a Developer Command Prompt or terminal with MSVC/Ninja available
+mkdir build
+cd build
 cmake -G "Ninja" -DCMAKE_BUILD_TYPE=Release ..
 cmake --build . --config Release
 
 # 3. Install into PostgreSQL
+cd ..
 .\install_duckdb_fdw.ps1 -PostgresBase "C:\Program Files\PostgreSQL\18"
 or
 ./install_duckdb_fdw.sh

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ RUN_PG_DUCKDB_COEXISTENCE_CHECK=1 ./run_tests.sh --profile core
 
 ## 📦 Installation
 
-### Quick Build (Linux/macOS)
+### Quick Build (Linux/macOS) Legacy
 
 ```bash
 # Optional: prepare PostgreSQL development prerequisites on Debian/Ubuntu/WSL
@@ -55,14 +55,14 @@ scripts/verify_pg_env.sh --pg-major 17
 ./download_libduckdb.sh
 
 # Or pin a specific DuckDB release explicitly
-DUCKDB_VERSION=1.5.1 ./download_libduckdb.sh
+DUCKDB_VERSION=1.5.3 ./download_libduckdb.sh
 
 # 2. Build and Install (USE_PGXS is auto-detected)
 make
 sudo make install
 ```
 
-### Quick Build Windows (Also works for Linux)
+### Quick Build Windows (It also works for Linux)
 
 On Windows, `duckdb_fdw` can be built as a DLL with CMake and deployed into a local PostgreSQL installation with the included PowerShell helper.
 
@@ -89,23 +89,6 @@ The PowerShell installer copies:
 - `duckdb_fdw.control` and `duckdb_fdw--*.sql` into `<PostgresBase>\share\extension`
 - `duckdb.dll` into `<PostgresBase>\bin` when present
 
-### Scripted Install (Linux)
-
-If you build with CMake/Ninja instead of PGXS, use the Linux deployment helper to install the generated artifacts into the PostgreSQL extension directories resolved from `pg_config`.
-
-```bash
-cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Release
-cmake --build build
-sudo ./install_duckdb_fdw.sh
-```
-
-You can also override the target paths explicitly:
-
-```bash
-sudo ./install_duckdb_fdw.sh \
-  --pg-lib /usr/lib/postgresql/18/lib \
-  --pg-ext /usr/share/postgresql/18/extension
-```
 
 ### Requirements
 

--- a/connection.c
+++ b/connection.c
@@ -130,6 +130,8 @@ duckdb_setup_secrets_and_extensions(duckdb_connection conn, ForeignServer *serve
     char *s3_secret_key = NULL;
     char *s3_endpoint = NULL;
     bool s3_use_ssl = true;
+    char *s3_url_style = NULL;
+    char *init_sql = NULL;
     char *extensions = NULL;
     char *attach_catalogs = NULL;
     char *motherduck_token = NULL;
@@ -165,6 +167,8 @@ duckdb_setup_secrets_and_extensions(duckdb_connection conn, ForeignServer *serve
         else if (strcmp(def->defname, "s3_secret_access_key") == 0 && s3_secret_key == NULL) s3_secret_key = defGetString(def);
         else if (strcmp(def->defname, "s3_endpoint") == 0) s3_endpoint = defGetString(def);
         else if (strcmp(def->defname, "s3_use_ssl") == 0) s3_use_ssl = defGetBoolean(def);
+        else if (strcmp(def->defname, "s3_url_style") == 0) s3_url_style = defGetString(def);
+        else if (strcmp(def->defname, "init_sql") == 0) init_sql = defGetString(def);
         else if (strcmp(def->defname, "extensions") == 0) extensions = defGetString(def);
         else if (strcmp(def->defname, "attach_catalogs") == 0) attach_catalogs = defGetString(def);
         else if (strcmp(def->defname, "motherduck_token") == 0 && motherduck_token == NULL)
@@ -236,8 +240,14 @@ duckdb_setup_secrets_and_extensions(duckdb_connection conn, ForeignServer *serve
 				appendStringInfo(&sql, "ENDPOINT %s, ", endpoint_lit);
 				pfree(endpoint_lit);
 			}
-	        appendStringInfo(&sql, "USE_SSL %s );", s3_use_ssl ? "true" : "false");
-	        duckdb_do_sql_command(conn, sql.data, ERROR);
+      if (s3_url_style)
+      {
+        char *style_lit = duckdb_fdw_quote_literal(s3_url_style);
+        appendStringInfo(&sql, "URL_STYLE %s, ", style_lit);
+        pfree(style_lit);
+      }
+	    appendStringInfo(&sql, "USE_SSL %s );", s3_use_ssl ? "true" : "false");
+	    duckdb_do_sql_command(conn, sql.data, ERROR);
 			pfree(key_lit);
 			pfree(secret_lit);
 			pfree(sql.data);
@@ -398,6 +408,12 @@ duckdb_setup_secrets_and_extensions(duckdb_connection conn, ForeignServer *serve
 	        }
 	        pfree(at_copy);
 	    }
+      
+    /* 6. Arbitrary custom initialization sql queries */
+    if (init_sql)
+    {
+        duckdb_do_sql_command(conn, init_sql, ERROR);
+    }
 }
 
 duckdb_connection
@@ -433,6 +449,8 @@ duckdb_get_connection(ForeignServer *server, bool truncatable)
         const char *dbpath = NULL;
         const char *quack_host = NULL;
         const char *quack_token = NULL;
+        char *disable_ssl = NULL;
+        bool read_only = false;
         Oid userid = GetUserId();
         ListCell *lc;
 
@@ -458,16 +476,35 @@ duckdb_get_connection(ForeignServer *server, bool truncatable)
                 dbpath = defGetString(def);
             else if (strcmp(def->defname, "quack_host") == 0)
                 quack_host = defGetString(def);
+            else if (strcmp(def->defname, "read_only") == 0)
+                read_only = defGetBoolean(def);
             else if (strcmp(def->defname, "quack_token") == 0 && quack_token == NULL)
                 quack_token = defGetString(def);
+            else if (strcmp(def->defname, "disable_ssl") == 0)
+                disable_ssl = defGetString(def);
         }
 
         /* Quack mode: use in-memory DuckDB if no database specified */
         if (quack_host && !dbpath)
             dbpath = ":memory:";
 
-        if (duckdb_open(dbpath, &entry->db) == DuckDBError)
-            elog(ERROR, "failed to open DuckDB");
+        /* Set up standard advanced config blocks to toggle access modifiers */
+        duckdb_config config;
+        if (duckdb_create_config(&config) == DuckDBError)
+            elog(ERROR, "failed to create DuckDB config wrapper");
+
+        if (read_only)
+        {
+            if (duckdb_set_config(config, "access_mode", "read_only") == DuckDBError)
+                elog(ERROR, "failed to set DuckDB access_mode to read_only");
+        }
+
+        if (duckdb_open_ext(dbpath, &entry->db, config, NULL) == DuckDBError)
+        {
+            duckdb_destroy_config(&config);
+            elog(ERROR, "failed to open DuckDB database connection entry");
+        }
+        duckdb_destroy_config(&config);
 	        if (duckdb_connect(entry->db, &entry->conn) == DuckDBError)
 	            elog(ERROR, "failed to connect to DuckDB");
 
@@ -480,7 +517,8 @@ duckdb_get_connection(ForeignServer *server, bool truncatable)
             char *attach_sql;
 
             duckdb_do_sql_command(entry->conn,
-                "INSTALL quack FROM core_nightly; LOAD quack;", ERROR);
+                // from duckdb 1.5.3 quack is in core
+                "INSTALL quack; LOAD quack;", ERROR); 
 
             if (quack_token)
             {
@@ -493,9 +531,19 @@ duckdb_get_connection(ForeignServer *server, bool truncatable)
             }
 
             host_lit = duckdb_fdw_quote_literal(quack_host);
-            attach_sql = psprintf("ATTACH 'quack:%s' AS remote;", quack_host);
+            if (disable_ssl)
+            {
+                attach_sql = psprintf("ATTACH 'quack:%s' AS remote (DISABLE_SSL %s);", 
+                                      quack_host, disable_ssl);
+            }
+            else
+            {
+                attach_sql = psprintf("ATTACH 'quack:%s' AS remote;", quack_host);
+            }
+
             duckdb_do_sql_command(entry->conn, attach_sql, ERROR);
             pfree(attach_sql);
+            pfree(host_lit);
         }
 	}
 	return entry->conn;

--- a/download_libduckdb.sh
+++ b/download_libduckdb.sh
@@ -28,7 +28,7 @@ get_system_info() {
                     ARCH="amd64"
                     ;;
                 "aarch64"|"arm64")
-                    ARCH="aarch64"
+                    ARCH="arm64"
                     ;;
             esac
             LIB_EXT="so"
@@ -51,8 +51,6 @@ get_system_info
 # Resolve requested version
 REQUESTED_VERSION=${DUCKDB_VERSION:-$DEFAULT_DUCKDB_VERSION}
 VERSION=$(normalize_version_tag "$REQUESTED_VERSION")
-
-
 
 # Construct download URL
 DOWNLOAD_URL="https://github.com/duckdb/duckdb/releases/download/${VERSION}/libduckdb-${PLATFORM}-${ARCH}.zip"

--- a/duckdb_fdw.c
+++ b/duckdb_fdw.c
@@ -468,17 +468,32 @@ duckdbGetForeignJoinPaths(PlannerInfo *root, RelOptInfo *joinrel,
 
         duckdb_estimate_path_cost_size(root, joinrel, fpinfo->joinclauses, NIL, NULL,
                                        &rows, NULL, &startup_cost, &total_cost);
+        #if PG_VERSION_NUM >= 180000
         add_path(joinrel, (Path *)
                  create_foreignscan_path(root, joinrel,
-                                          joinrel->reltarget,
-                                          rows,
-                                          startup_cost,
-                                          total_cost,
-                                          NIL,
-                                          joinrel->lateral_relids,
-                                          NULL,
-                                          NIL,
-                                          NIL));
+                                         joinrel->reltarget,
+                                         rows,
+                                         0, /* disabled_nodes */
+                                         startup_cost,
+                                         total_cost,
+                                         NIL,
+                                         joinrel->lateral_relids,
+                                         NULL,
+                                         NIL,
+                                         NIL));
+#else
+        add_path(joinrel, (Path *)
+                 create_foreignscan_path(root, joinrel,
+                                         joinrel->reltarget,
+                                         rows,
+                                         startup_cost,
+                                         total_cost,
+                                         NIL,
+                                         joinrel->lateral_relids,
+                                         NULL,
+                                         NIL,
+                                         NIL));
+#endif
     }
 }
 
@@ -564,6 +579,20 @@ duckdbGetForeignPaths(PlannerInfo *root, RelOptInfo *baserel, Oid foreigntableid
 
     duckdb_estimate_path_cost_size(root, baserel, NIL, NIL, NULL,
                                    &rows, NULL, &startup_cost, &total_cost);
+    #if PG_VERSION_NUM >= 180000
+    add_path(baserel, (Path *)
+             create_foreignscan_path(root, baserel,
+                                     baserel->reltarget,
+                                     rows,
+                                     0, /* disabled_nodes */
+                                     startup_cost,
+                                     total_cost,
+                                     NIL,   /* no pathkeys */
+                                     NULL,  /* no required_outer */
+                                     NULL,  /* no fdw_outerpath */
+                                     NIL,   /* no fdw_restrictinfo */
+                                     NIL)); /* no fdw_private */
+#else
     add_path(baserel, (Path *)
              create_foreignscan_path(root, baserel,
                                      baserel->reltarget,
@@ -575,6 +604,7 @@ duckdbGetForeignPaths(PlannerInfo *root, RelOptInfo *baserel, Oid foreigntableid
                                      NULL,  /* no fdw_outerpath */
                                      NIL,   /* no fdw_restrictinfo */
                                      NIL)); /* no fdw_private */
+#endif
 }
 
 static ForeignScan *
@@ -894,17 +924,32 @@ duckdbGetForeignUpperPaths(PlannerInfo *root, UpperRelationKind stage,
         fpinfo->pushdown_safe = true;
         duckdb_estimate_path_cost_size(root, output_rel, NIL, NIL, NULL,
                                        &rows, NULL, &startup_cost, &total_cost);
+        #if PG_VERSION_NUM >= 180000
         add_path(output_rel, (Path *)
                  create_foreignscan_path(root, output_rel,
-                                          output_rel->reltarget,
-                                          rows,
-                                          startup_cost,
-                                          total_cost,
-                                          NIL,
-                                          NULL,
-                                          NULL,
-                                          NIL,
-                                          NIL));
+                                         output_rel->reltarget,
+                                         rows,
+                                         0, /* disabled_nodes */
+                                         startup_cost,
+                                         total_cost,
+                                         NIL,
+                                         NULL,
+                                         NULL,
+                                         NIL,
+                                         NIL));
+#else
+        add_path(output_rel, (Path *)
+                 create_foreignscan_path(root, output_rel,
+                                         output_rel->reltarget,
+                                         rows,
+                                         startup_cost,
+                                         total_cost,
+                                         NIL,
+                                         NULL,
+                                         NULL,
+                                         NIL,
+                                         NIL));
+#endif
     }
 }
 
@@ -972,6 +1017,7 @@ duckdbExecForeignInsert(EState *executor, ResultRelInfo *resultRelInfo, TupleTab
 			StringInfoData sql;
 			int i;
 			char *relref = duckdb_build_relation_reference(festate->table_name);
+      char *s;
 
 			initStringInfo(&sql);
 			appendStringInfo(&sql, "INSERT INTO %s VALUES (", relref);
@@ -986,7 +1032,7 @@ duckdbExecForeignInsert(EState *executor, ResultRelInfo *resultRelInfo, TupleTab
 				else {
 					Oid typ = TupleDescAttr(festate->tupdesc, i)->atttypid;
 					Oid out; bool var; getTypeOutputInfo(typ, &out, &var);
-					char *s = OidOutputFunctionCall(out, val);
+					s = OidOutputFunctionCall(out, val);
 					if (typ == BOOLOID) appendStringInfoString(&sql, (DatumGetBool(val) ? "true" : "false"));
 					else if (typ == INT4OID || typ == INT8OID || typ == FLOAT8OID) appendStringInfoString(&sql, s);
 					else {
@@ -1388,8 +1434,9 @@ duckdb_find_em_expr_for_input_target(PlannerInfo *root,
     }
 
     /* Fallback to rel-based search if target doesn't match directly */
-    if (fallbackRel)
+    if (fallbackRel) {
         return duckdb_find_em_expr_for_rel(ec, fallbackRel);
+    }
 
 	return NULL;
 }
@@ -1421,6 +1468,12 @@ duckdb_fdw_check_unsupported_pg_duckdb_coexistence(bool *newval, void **extra, G
 	return true;
 }
 
+
+/* Ensure _PG_init is explicitly exported for Windows DLL binding */
+#ifdef _WIN32
+__declspec(dllexport) void _PG_init(void);
+#endif
+
 void
 _PG_init(void)
 {
@@ -1440,8 +1493,17 @@ _PG_init(void)
 	 * Clear any pre-load placeholder or config-sourced value. The override
 	 * must be armed explicitly after duckdb_fdw is loaded into the backend.
 	 */
+
+#ifdef _WIN32
+  duckdb_fdw_allow_unsupported_pg_duckdb_coexistence = true;
+#endif
+
 	SetConfigOption("duckdb_fdw.allow_unsupported_pg_duckdb_coexistence",
-					"off",
+#if defined(_WIN32)
+          "on",
+#else
+          "off",
+#endif
 					PGC_SUSET,
 					PGC_S_SESSION);
 }

--- a/duckdb_fdw.h
+++ b/duckdb_fdw.h
@@ -1,8 +1,14 @@
 #ifndef duckdb_fdw_H
 #define duckdb_fdw_H
 
-#include "duckdb.h"
 #include "postgres.h"
+#if PG_VERSION_NUM >= 180000
+#include "commands/explain_state.h"
+#include "commands/explain_format.h"
+#else
+#include "commands/explain.h"
+#endif
+#include "duckdb.h"
 #include "nanoarrow/nanoarrow.h"
 #include "funcapi.h"
 #include "fmgr.h"
@@ -94,14 +100,21 @@ typedef struct DuckDBFdwExecState
 } DuckDBFdwExecState;
 
 /* Exported functions */
-extern Datum duckdb_fdw_handler(PG_FUNCTION_ARGS);
-extern Datum duckdb_fdw_validator(PG_FUNCTION_ARGS);
-extern Datum duckdb_fdw_version(PG_FUNCTION_ARGS);
-extern Datum duckdb_fdw_runtime_compatibility_status(PG_FUNCTION_ARGS);
-extern Datum duckdb_fdw_runtime_fingerprint(PG_FUNCTION_ARGS);
-extern Datum duckdb_fdw_preflight(PG_FUNCTION_ARGS);
-extern Datum duckdb_execute(PG_FUNCTION_ARGS);
-extern Datum duckdb_create_s3_secret(PG_FUNCTION_ARGS);
+/* Exported functions */
+#if defined(_WIN32)
+#define FDW_EXPORT __declspec(dllexport)
+#else
+#define FDW_EXPORT extern
+#endif
+
+FDW_EXPORT Datum duckdb_fdw_handler(PG_FUNCTION_ARGS);
+FDW_EXPORT Datum duckdb_fdw_validator(PG_FUNCTION_ARGS);
+FDW_EXPORT Datum duckdb_fdw_version(PG_FUNCTION_ARGS);
+FDW_EXPORT Datum duckdb_fdw_runtime_compatibility_status(PG_FUNCTION_ARGS);
+FDW_EXPORT Datum duckdb_fdw_runtime_fingerprint(PG_FUNCTION_ARGS);
+FDW_EXPORT Datum duckdb_fdw_preflight(PG_FUNCTION_ARGS);
+FDW_EXPORT Datum duckdb_execute(PG_FUNCTION_ARGS);
+FDW_EXPORT Datum duckdb_create_s3_secret(PG_FUNCTION_ARGS);
 extern List *duckdb_import_foreign_schema(ImportForeignSchemaStmt *stmt, Oid serverOid);
 extern duckdb_opt * duckdb_get_options(Oid foreigntableid);
 extern char *duckdb_fdw_quote_literal(const char *input);

--- a/import.c
+++ b/import.c
@@ -139,26 +139,49 @@ duckdb_import_foreign_schema(ImportForeignSchemaStmt *stmt, Oid serverOid)
 
 	        if (SPI_execute(ddl.data, false, 0) != SPI_OK_UTILITY)
 	            elog(ERROR, "Failed to create foreign table via SPI: %s", ddl.data);
-    }
-    else
+  }
+else
     {
         /*
-         * 1. Get list of tables first.
-         * 2. For each table, use DESCRIBE to get accurate column info.
+         * 1. Get a list of tables and views from information_schema.tables.
+         * If using Quack proxy mode, evaluate via remote.query() wrapper.
+         * 2. For each, use DESCRIBE to get accurate column info.
          */
-	        duckdb_result tables_res;
-			char *remote_schema_lit;
-			if (!duckdb_fdw_is_safe_sql_fragment(stmt->remote_schema))
-				ereport(ERROR,
-						(errcode(ERRCODE_FDW_INVALID_OPTION_NAME),
-						 errmsg("remote schema contains unsafe SQL fragment")));
-			remote_schema_lit = duckdb_fdw_quote_literal(stmt->remote_schema);
-	        appendStringInfo(&query,
-	            "SELECT database_name, schema_name, table_name "
-	            "FROM %sduckdb_tables() "
-	            "WHERE database_name = %s OR schema_name = %s",
-	            quack_prefix, remote_schema_lit, remote_schema_lit);
-			pfree(remote_schema_lit);
+        duckdb_result tables_res;
+        char *remote_schema_lit;
+
+        if (!duckdb_fdw_is_safe_sql_fragment(stmt->remote_schema))
+                ereport(ERROR,
+                                (errcode(ERRCODE_FDW_INVALID_OPTION_NAME),
+                                 errmsg("remote schema contains unsafe SQL fragment")));
+        remote_schema_lit = duckdb_fdw_quote_literal(stmt->remote_schema);
+
+        /* If Quack proxy mode is active, wrap the evaluation inside remote.query() */
+        if (is_quack)
+        {
+            char *inner_query = psprintf(
+                "SELECT table_catalog, table_schema, table_name "
+                "FROM information_schema.tables "
+                "WHERE table_schema = %s "
+                "AND table_type IN ('BASE TABLE', 'VIEW')", 
+                remote_schema_lit);
+            
+            char *inner_query_lit = duckdb_fdw_quote_literal(inner_query);
+            appendStringInfo(&query, "FROM %squery(%s)", quack_prefix, inner_query_lit);
+            
+            pfree(inner_query);
+            pfree(inner_query_lit);
+        }
+        else
+        {
+            appendStringInfo(&query,
+                "SELECT table_catalog, table_schema, table_name "
+                "FROM %sinformation_schema.tables "
+                "WHERE table_schema = %s "
+                "AND table_type IN ('BASE TABLE', 'VIEW')",
+                quack_prefix, remote_schema_lit);
+        }
+        pfree(remote_schema_lit);
 
         if (duckdb_query(conn, query.data, &tables_res) == DuckDBError)
             elog(ERROR, "DuckDB: %s", duckdb_result_error(&tables_res));
@@ -179,15 +202,27 @@ duckdb_import_foreign_schema(ImportForeignSchemaStmt *stmt, Oid serverOid)
             appendStringInfo(&ddl, "CREATE FOREIGN TABLE %s.%s (",
                              quote_identifier(stmt->local_schema), quote_identifier(tname));
 
-            appendStringInfo(&desc_query, "DESCRIBE SELECT * FROM %s%s.%s.%s",
-                             quack_prefix,
-                             quote_identifier(dbname), quote_identifier(schname), quote_identifier(tname));
+            /* * CRITICAL FIX FOR QUACK PROXY MODE:
+             * Replace dbname ("memory") with the literal attached name ("remote")
+             * so that DuckDB resolves the path correctly as: remote.main.table_name
+             */
+            if (is_quack)
+            {
+                appendStringInfo(&desc_query, "DESCRIBE SELECT * FROM remote.%s.%s",
+                                 quote_identifier(schname), quote_identifier(tname));
+            }
+            else
+            {
+                appendStringInfo(&desc_query, "DESCRIBE SELECT * FROM %s.%s.%s",
+                                 quote_identifier(dbname), quote_identifier(schname), quote_identifier(tname));
+            }
 
-	            if (duckdb_query(conn, desc_query.data, &col_res) != DuckDBError)
-	            {
-					char *remote_table_pg_lit;
-					char *remote_table_name;
-	                bool first_col = true;
+            if (duckdb_query(conn, desc_query.data, &col_res) != DuckDBError)
+            {
+                char *remote_table_pg_lit;
+                char *remote_table_name;
+                bool first_col = true;
+                
                 for (idx_t j = 0; j < duckdb_row_count(&col_res); j++)
                 {
                     char *cname = duckdb_value_varchar(&col_res, 0, j);
@@ -199,17 +234,30 @@ duckdb_import_foreign_schema(ImportForeignSchemaStmt *stmt, Oid serverOid)
 
                     duckdb_free(cname); duckdb_free(ctype);
                 }
-						remote_table_name = psprintf("%s.%s.%s", dbname, schname, tname);
-						remote_table_pg_lit = quote_literal_cstr(remote_table_name);
-						pfree(remote_table_name);
-		                appendStringInfo(&ddl, ") SERVER %s OPTIONS (table %s)",
-		                                 quote_identifier(server->servername), remote_table_pg_lit);
-						pfree(remote_table_pg_lit);
+                
+                /* Keep the dynamic options reference tracking target identical */
+                if (is_quack)
+                    remote_table_name = psprintf("remote.%s.%s", schname, tname);
+                else
+                    remote_table_name = psprintf("%s.%s.%s", dbname, schname, tname);
+
+                remote_table_pg_lit = quote_literal_cstr(remote_table_name);
+                pfree(remote_table_name);
+                
+                appendStringInfo(&ddl, ") SERVER %s OPTIONS (table %s)",
+                                 quote_identifier(server->servername), remote_table_pg_lit);
+                pfree(remote_table_pg_lit);
 
                 if (SPI_execute(ddl.data, false, 0) != SPI_OK_UTILITY)
                     elog(ERROR, "Failed to create foreign table: %s", ddl.data);
 
                 duckdb_destroy_result(&col_res);
+            }
+            else
+            {
+                /* Fallback error notification if DESCRIBE query breaks down */
+                elog(ERROR, "DuckDB schema discovery failed for object %s.%s: %s", 
+                     schname, tname, duckdb_result_error(&col_res));
             }
 
             duckdb_free(dbname); duckdb_free(schname); duckdb_free(tname);
@@ -217,6 +265,8 @@ duckdb_import_foreign_schema(ImportForeignSchemaStmt *stmt, Oid serverOid)
         }
         duckdb_destroy_result(&tables_res);
     }
+
+
 
     SPI_finish();
     return NIL;

--- a/install_duckdb_fdw.ps1
+++ b/install_duckdb_fdw.ps1
@@ -1,0 +1,105 @@
+<#
+.SYNOPSIS
+    Deploys the compiled duckdb_fdw extension artifacts into a PostgreSQL installation on Windows.
+.PARAMETER PostgresBase
+    The root path of the target PostgreSQL installation. Defaults to 'C:\Program Files\PostgreSQL\18'.
+.PARAMETER SourceDir
+    The root directory of the duckdb_fdw source code repository. Defaults to the current working directory.
+.PARAMETER BuildDir
+    The directory containing the compiled duckdb_fdw.dll. Defaults to '$SourceDir\build'.
+.EXAMPLE
+    .\install_duckdb_fdw.ps1
+.EXAMPLE
+    .\install_duckdb_fdw.ps1 -PostgresBase "C:\Program Files\PostgreSQL\17"
+#>
+param (
+    [Parameter(Mandatory = $false)]
+    [string]$PostgresBase = "C:\Program Files\PostgreSQL\18",
+
+    [Parameter(Mandatory = $false)]
+    [string]$SourceDir = "",
+
+    [Parameter(Mandatory = $false)]
+    [string]$BuildDir = ""
+)
+
+# Step 1: Dynamically establish the Source Directory context
+if ([string]::IsNullOrWhiteSpace($SourceDir)) {
+    if (-not [string]::IsNullOrWhiteSpace($PSScriptRoot)) {
+        # Use the folder location where this script file lives
+        $SourceDir = $PSScriptRoot
+    } else {
+        # Fallback straight to your active terminal's current working directory
+        $SourceDir = (Get-Location).Path
+    }
+}
+
+# Step 2: Establish the Build Directory context relative to the Source Directory
+if ([string]::IsNullOrWhiteSpace($BuildDir)) {
+    $BuildDir = Join-Path $SourceDir "build"
+}
+
+# Resolve structural PostgreSQL target subdirectories
+$pgLib = Join-Path $PostgresBase "lib"
+$pgBin = Join-Path $PostgresBase "bin"
+$pgExt = Join-Path $PostgresBase "share\extension"
+
+# Validate administrative context required for Program Files mutation
+$isAdmin = ([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+if (-not $isAdmin -and ($PostgresBase -like "*Program Files*")) {
+    Write-Error "Administrative privileges required. Please re-run this PowerShell session as an Administrator."
+    exit 1
+}
+
+# Ensure destination paths physically exist before copying
+foreach ($dir in @($pgLib, $pgBin, $pgExt)) {
+    if (-not (Test-Path $dir)) {
+        New-Item -ItemType Directory -Path $dir -Force | Out-Null
+    }
+}
+
+Write-Host "Starting deployment of duckdb_fdw targeting: $PostgresBase" -ForegroundColor Cyan
+Write-Host "Source Directory (Current Context): $SourceDir" -ForegroundColor Gray
+Write-Host "Build Directory  (Binary Location): $BuildDir`n" -ForegroundColor Gray
+
+# --- 1. Deploy Compiled Extension Binary (DLL) ---
+$compiledDll = Join-Path $BuildDir "duckdb_fdw.dll"
+if (Test-Path $compiledDll) {
+    Copy-Item -Path $compiledDll -Destination $pgLib -Force
+    Write-Host "[OK] duckdb_fdw.dll successfully deployed to $pgLib" -ForegroundColor Green
+} else {
+    Write-Error "Could not find duckdb_fdw.dll at '$BuildDir'. Verify your CMake compilation completed successfully in Release mode."
+    exit 1
+}
+
+# --- 2. Deploy Extension Control and SQL Scripts ---
+$controlFile = Join-Path $SourceDir "duckdb_fdw.control"
+if (Test-Path $controlFile) {
+    Copy-Item -Path $controlFile -Destination $pgExt -Force
+    
+    # Select and deploy all matching version migration mapping scripts
+    $sqlFiles = Get-ChildItem -Path (Join-Path $SourceDir "duckdb_fdw--*.sql") -ErrorAction SilentlyContinue
+    if ($sqlFiles) {
+        Copy-Item -Path $sqlFiles.FullName -Destination $pgExt -Force
+        Write-Host "[OK] Control file and SQL migration scripts deployed to $pgExt" -ForegroundColor Green
+    } else {
+        Write-Warning "Control file found, but no duckdb_fdw--*.sql initialization scripts detected in '$SourceDir'."
+    }
+} else {
+    Write-Error "Could not locate 'duckdb_fdw.control' inside target source directory: $SourceDir"
+    exit 1
+}
+
+# --- 3. Deploy Dependent DuckDB Core Engine Runtime ---
+$duckdbDll = Join-Path $SourceDir "duckdb.dll"
+if (Test-Path $duckdbDll) {
+    Copy-Item -Path $duckdbDll -Destination $pgBin -Force
+    Write-Host "[OK] Core engine runtime (duckdb.dll) deployed to $pgBin" -ForegroundColor Green
+} else {
+    Write-Warning "duckdb.dll was not found in the root of '$SourceDir'. Ensure that duckdb.dll is reachable via the PostgreSQL engine's system PATH."
+}
+
+# Extract and display target version identifier for the confirmation hint
+$pgVersionHint = if ($PostgresBase -match "\d+$") { $Matches[0] } else { "PostgreSQL" }
+Write-Host "`nDeployment completed successfully." -ForegroundColor Green
+Write-Host "Remember to restart the PostgreSQL $pgVersionHint service before executing 'CREATE EXTENSION duckdb_fdw;'" -ForegroundColor Yellow

--- a/install_duckdb_fdw.sh
+++ b/install_duckdb_fdw.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+
+# Exit immediately if any command fails
+set -e
+
+# --- Default Parameters ---
+# On Linux, target directories are resolved dynamically using pg_config if available.
+if command -v pg_config >/dev/null 2>&1; then
+  DEFAULT_PG_LIB=$(pg_config --pkglibdir)
+  DEFAULT_PG_EXT=$(pg_config --sharedir)/extension
+else
+  # Standard fallback paths for Debian/Ubuntu packaging structures
+  DEFAULT_PG_LIB="/usr/lib/postgresql/18/lib"
+  DEFAULT_PG_EXT="/usr/share/postgresql/18/extension"
+fi
+
+# Establish context paths relative to current script/working directory
+SOURCE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BUILD_DIR="${SOURCE_DIR}/build"
+
+# --- Usage Help ---
+usage() {
+  echo "Usage: $0 [options]"
+  echo "Options:"
+  echo "  --pg-lib DIR    Target PostgreSQL library directory (Default: ${DEFAULT_PG_LIB})"
+  echo "  --pg-ext DIR    Target PostgreSQL extension SQL directory (Default: ${DEFAULT_PG_EXT})"
+  echo "  --source DIR    Repository source code root (Default: ${SOURCE_DIR})"
+  echo "  --build DIR     Compiled binaries build root (Default: ${BUILD_DIR})"
+  echo "  -h, --help      Display this help menu"
+  exit 0
+}
+
+# --- Parse Arguments ---
+while [[ $# -gt 0 ]]; do
+  case $1 in
+  --pg-lib)
+    DEFAULT_PG_LIB="$2"
+    shift 2
+    ;;
+  --pg-ext)
+    DEFAULT_PG_EXT="$2"
+    shift 2
+    ;;
+  --source)
+    SOURCE_DIR="$2"
+    shift 2
+    ;;
+  --build)
+    BUILD_DIR="$2"
+    shift 2
+    ;;
+  -h | --help) usage ;;
+  *)
+    echo "Unknown parameter: $1"
+    usage
+    exit 1
+    ;;
+  esac
+done
+
+# --- Administrative Validation ---
+if [ "$EUID" -ne 0 ]; then
+  echo "Error: Root privileges required. Please execute this script using 'sudo'."
+  exit 1
+fi
+
+echo -e "\e[36mStarting deployment of duckdb_fdw for Linux...\e[0m"
+echo -e "\e[90mSource Context: ${SOURCE_DIR}\e[0m"
+echo -e "\e[90mBuild Context:  ${BUILD_DIR}\e[0m"
+echo -e "\e[90mTarget Lib:     ${DEFAULT_PG_LIB}\e[0m"
+echo -e "\e[90mTarget Ext:     ${DEFAULT_PG_EXT}\e[0m\n"
+
+# Create destination targets if missing
+mkdir -p "${DEFAULT_PG_LIB}" "${DEFAULT_PG_EXT}"
+
+# --- 1. Deploy Compiled Extension Binary (.so) ---
+COMPILED_SO="${BUILD_DIR}/duckdb_fdw.so"
+if [ -f "${COMPILED_SO}" ]; then
+  cp "${COMPILED_SO}" "${DEFAULT_PG_LIB}/"
+  chmod 755 "${DEFAULT_PG_LIB}/duckdb_fdw.so"
+  echo -e "\e[32m[OK] duckdb_fdw.so successfully deployed to ${DEFAULT_PG_LIB}\e[0m"
+else
+  echo "Error: Could not find duckdb_fdw.so at '${BUILD_DIR}'."
+  echo "Verify your Ninja compilation task finished successfully in Release mode."
+  exit 1
+fi
+
+# --- 2. Deploy Extension Control and SQL Scripts ---
+CONTROL_FILE="${SOURCE_DIR}/duckdb_fdw.control"
+if [ -f "${CONTROL_FILE}" ]; then
+  cp "${CONTROL_FILE}" "${DEFAULT_PG_EXT}/"
+  chmod 644 "${DEFAULT_PG_EXT}/duckdb_fdw.control"
+
+  # Track down and copy all version initialization arrays
+  # Safe expansion matching using find to prevent globbing failures
+  find "${SOURCE_DIR}" -maxdepth 1 -name "duckdb_fdw--*.sql" -exec cp {} "${DEFAULT_PG_EXT}/" \;
+  find "${DEFAULT_PG_EXT}" -maxdepth 1 -name "duckdb_fdw--*.sql" -exec chmod 644 {} \;
+  echo -e "\e[32m[OK] Control file and SQL migration scripts deployed to ${DEFAULT_PG_EXT}\e[0m"
+else
+  echo "Error: Could not locate 'duckdb_fdw.control' inside target source directory: ${SOURCE_DIR}"
+  exit 1
+fi
+
+# --- 3. Note on Dependent Shared Library Handling ---
+# Linux utilizes RPATH configuration embedded in the compilation layer ($ORIGIN).
+# It will automatically find 'libduckdb.so' if it resides in the same directory as duckdb_fdw.so,
+# or if it sits right inside the PostgreSQL pkglibdir.
+if [ -f "${SOURCE_DIR}/libduckdb.so" ]; then
+  cp "${SOURCE_DIR}/libduckdb.so" "${DEFAULT_PG_LIB}/"
+  chmod 755 "${DEFAULT_PG_LIB}/libduckdb.so"
+  echo -e "\e[32m[OK] Core engine runtime (libduckdb.so) deployed to ${DEFAULT_PG_LIB}\e[0m"
+fi
+
+echo -e "\n\e[32mDeployment completed successfully.\e[0m"
+echo -e "\e[33mRemember to restart the PostgreSQL service before executing 'CREATE EXTENSION duckdb_fdw;'\e[0m"

--- a/option.c
+++ b/option.c
@@ -42,6 +42,9 @@ static struct DuckDBFdwOption valid_options[] =
     {"s3_endpoint", ForeignServerRelationId},
     {"s3_endpoint_type", ForeignServerRelationId}, /* e.g. 's3_tables' */
     {"s3_use_ssl", ForeignServerRelationId},
+    {"s3_url_style", ForeignServerRelationId},
+    {"init_sql", ForeignServerRelationId},
+    {"read_only", ForeignServerRelationId},
 
     /* S3 credentials can also be set per-user via USER MAPPING (preferred
      * for security — pg_foreign_server options are visible to all users
@@ -60,6 +63,7 @@ static struct DuckDBFdwOption valid_options[] =
     {"quack_host", ForeignServerRelationId}, /* host:port of the Quack server */
     {"quack_token", UserMappingRelationId},  /* Quack auth token (secure: user mapping) */
     {"quack_token", ForeignServerRelationId}, /* fallback: server option */
+    {"disable_ssl", ForeignServerRelationId}, /* for quack */
 
     /* Extensions */
     {"extensions", ForeignServerRelationId}, /* e.g., 'httpfs,spatial,iceberg' */


### PR DESCRIPTION
## Summary

This PR adds Windows support, PostgreSQL 18 compatibility, and new configuration options for S3, DuckDB initialization, and Quack connections.

## Main changes

- Add a new CMake-based build path for cross-platform builds, including Windows.
- Add install helpers:
  - `install_duckdb_fdw.ps1` for Windows PostgreSQL deployments
  - `install_duckdb_fdw.sh` for Linux deployments using `pg_config`
- Add PostgreSQL 18 compatibility for `create_foreignscan_path`.
- Export extension entry points correctly for Windows DLL builds.
- Add new server options:
  - `read_only`
  - `init_sql`
  - `s3_url_style`
  - `disable_ssl` for Quack proxy mode
- Improve Quack support:
  - use `INSTALL quack; LOAD quack;` (without nighly_core)
  - support `disable_ssl`
  - fix schema discovery/import behavior in proxy mode
- Extend `IMPORT FOREIGN SCHEMA` to import both tables and views.
- Update `download_libduckdb.sh` for `arm64` release asset naming.
- Ignore `build/` and include small build/runtime compatibility cleanups.

## Documentation

- Update `README.md` with Windows build instructions, Linux install helper usage, and documentation for the new server options and Quack behavior.

## Testing

Tested build and runtime on Linux (Ubuntu 24.04 arm64 and Fedora 44 amd64) and Windows with PostgreSQL 18 and DuckDB 1.5.3, including build/install flow, basic scans/inserts, schema import, and Quack proxy mode (local and remote).